### PR TITLE
Improve interactive input rendering responsiveness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ BACKBOARD_API_KEY=your_key_here
 # Optional.
 # BACKBOARD_API_URL=https://app.backboard.io/api
 
+# Optional interactive render ceiling (1-120, default: 60).
+# Lower this for slow terminals, SSH, or tmux sessions.
+# BACKBOARD_MAX_FPS=30
+
 # Optional override for `backboard login`.
 # This is the OAuth client id from the Backboard dashboard.
 # BACKBOARD_OAUTH_CLIENT_ID=your_oauth_client_id_here

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ BACKBOARD_API_KEY=your_key_here
 # Optional.
 # BACKBOARD_API_URL=https://app.backboard.io/api
 
-# Optional interactive render ceiling (1-120, default: 60).
+# Optional interactive render ceiling (1-120, default: 30).
 # Lower this for slow terminals, SSH, or tmux sessions.
 # BACKBOARD_MAX_FPS=30
 

--- a/README.md
+++ b/README.md
@@ -318,12 +318,16 @@ Most users do not need environment variables.
 | `BACKBOARD_API_URL`                  | Override the API base URL; defaults to `https://app.backboard.io/api` |
 | `BACKBOARD_OAUTH_CLIENT_ID`          | Override the first-party public OAuth client ID                       |
 | `BACKBOARD_ALLOW_INSECURE_API_URL=1` | Permit a non-HTTPS API URL for internal development                   |
+| `BACKBOARD_MAX_FPS`                  | Set interactive rendering to 1-120 FPS; defaults to 30                |
 | `BROWSER_PATH`                     | Use a specific Chrome or Chromium executable                          |
 | `BROWSER_CDP_URL`                  | Connect the Browser tool to an existing CDP HTTP endpoint             |
 | `BROWSER_WS_URL`                   | Connect the Browser tool to an existing CDP WebSocket endpoint        |
 
 Environment variables override saved Backboard credentials where applicable.
 Never commit real credentials to `.env`.
+
+Lower `BACKBOARD_MAX_FPS` for slow SSH or tmux connections, or raise it to 60
+or 120 on faster local terminals.
 
 ## Run from source
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -58,7 +58,10 @@ import { createDefaultTools } from "../tools/index.ts";
 import { App } from "../ui/App.tsx";
 import { AuthScreen } from "../ui/AuthScreen.tsx";
 import { CLEAR_VISIBLE_SCREEN } from "../ui/hooks/ResizeStabilizer.constants.ts";
-import { interactiveRenderOptions } from "../ui/renderOptions.ts";
+import {
+	interactiveRenderOptions,
+	resolveInteractiveRenderConfig,
+} from "../ui/renderOptions.ts";
 import { palette } from "../ui/theme/palette.ts";
 import { ThemeProvider } from "../ui/theme/ThemeProvider.tsx";
 import { detectTerminalBg } from "../ui/theme/terminalBg.ts";
@@ -229,10 +232,18 @@ async function main(): Promise<void> {
 					`Unknown --permission-mode "${config.flags.permissionMode}"; using ${permissions.mode} mode. Valid: ${PERMISSION_MODES.join(", ")}.`,
 				]
 			: [];
+	const interactiveRenderConfig = resolveInteractiveRenderConfig();
+	const renderWarnings = interactiveRenderConfig.warning
+		? [interactiveRenderConfig.warning]
+		: [];
 	// MCP init warnings (unset env vars, skipped/failed servers) are deliberately
 	// kept out of the startup surface — they cluttered every launch. Server status
 	// is still inspectable via /mcp; only the noisy startup emission is dropped.
-	const startupWarnings = [...hookConfig.warnings, ...permissionWarnings];
+	const startupWarnings = [
+		...hookConfig.warnings,
+		...permissionWarnings,
+		...renderWarnings,
+	];
 	for (const warning of startupWarnings) {
 		bus.emit({ type: "system:warning", message: warning });
 	}
@@ -433,7 +444,10 @@ async function main(): Promise<void> {
 	);
 	const instance = render(
 		app,
-		interactiveRenderOptions({ exitOnCtrlC: false }),
+		interactiveRenderOptions({
+			exitOnCtrlC: false,
+			maxFps: interactiveRenderConfig.maxFps,
+		}),
 	);
 
 	try {
@@ -463,7 +477,13 @@ async function runAuthScreen(): Promise<boolean> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(app, interactiveRenderOptions({ exitOnCtrlC: true }));
+	const instance = render(
+		app,
+		interactiveRenderOptions({
+			exitOnCtrlC: true,
+			maxFps: resolveInteractiveRenderConfig().maxFps,
+		}),
+	);
 	await instance.waitUntilExit();
 	if (didLogin) {
 		instance.clear();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -58,6 +58,7 @@ import { createDefaultTools } from "../tools/index.ts";
 import { App } from "../ui/App.tsx";
 import { AuthScreen } from "../ui/AuthScreen.tsx";
 import { CLEAR_VISIBLE_SCREEN } from "../ui/hooks/ResizeStabilizer.constants.ts";
+import { interactiveRenderOptions } from "../ui/renderOptions.ts";
 import { palette } from "../ui/theme/palette.ts";
 import { ThemeProvider } from "../ui/theme/ThemeProvider.tsx";
 import { detectTerminalBg } from "../ui/theme/terminalBg.ts";
@@ -430,10 +431,7 @@ async function main(): Promise<void> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(app, {
-		exitOnCtrlC: false,
-		maxFps: 12,
-	});
+	const instance = render(app, interactiveRenderOptions(false));
 
 	try {
 		await instance.waitUntilExit();
@@ -462,10 +460,7 @@ async function runAuthScreen(): Promise<boolean> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(app, {
-		exitOnCtrlC: true,
-		maxFps: 12,
-	});
+	const instance = render(app, interactiveRenderOptions(true));
 	await instance.waitUntilExit();
 	if (didLogin) {
 		instance.clear();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -59,7 +59,7 @@ import { App } from "../ui/App.tsx";
 import { AuthScreen } from "../ui/AuthScreen.tsx";
 import { CLEAR_VISIBLE_SCREEN } from "../ui/hooks/ResizeStabilizer.constants.ts";
 import {
-	interactiveRenderOptions,
+	type InteractiveRenderConfig,
 	resolveInteractiveRenderConfig,
 } from "../ui/renderOptions.ts";
 import { palette } from "../ui/theme/palette.ts";
@@ -115,6 +115,7 @@ async function main(): Promise<void> {
 		await runLogoutCommand();
 		return;
 	}
+	const interactiveRenderConfig = resolveInteractiveRenderConfig();
 
 	let config: Config;
 	while (true) {
@@ -124,7 +125,7 @@ async function main(): Promise<void> {
 		} catch (err) {
 			const error = err instanceof Error ? err : String(err);
 			if (shouldShowAuthScreen(error, earlyFlags)) {
-				const didLogin = await runAuthScreen();
+				const didLogin = await runAuthScreen(interactiveRenderConfig);
 				if (!didLogin) return;
 				continue;
 			}
@@ -232,10 +233,7 @@ async function main(): Promise<void> {
 					`Unknown --permission-mode "${config.flags.permissionMode}"; using ${permissions.mode} mode. Valid: ${PERMISSION_MODES.join(", ")}.`,
 				]
 			: [];
-	const interactiveRenderConfig = resolveInteractiveRenderConfig();
-	const renderWarnings = interactiveRenderConfig.warning
-		? [interactiveRenderConfig.warning]
-		: [];
+	const renderWarnings = headless ? [] : interactiveRenderConfig.warnings;
 	// MCP init warnings (unset env vars, skipped/failed servers) are deliberately
 	// kept out of the startup surface — they cluttered every launch. Server status
 	// is still inspectable via /mcp; only the noisy startup emission is dropped.
@@ -442,13 +440,10 @@ async function main(): Promise<void> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(
-		app,
-		interactiveRenderOptions({
-			exitOnCtrlC: false,
-			maxFps: interactiveRenderConfig.maxFps,
-		}),
-	);
+	const instance = render(app, {
+		exitOnCtrlC: false,
+		maxFps: interactiveRenderConfig.maxFps,
+	});
 
 	try {
 		await instance.waitUntilExit();
@@ -457,7 +452,9 @@ async function main(): Promise<void> {
 	}
 }
 
-async function runAuthScreen(): Promise<boolean> {
+async function runAuthScreen(
+	interactiveRenderConfig: InteractiveRenderConfig,
+): Promise<boolean> {
 	let didLogin = false;
 	const { hex: terminalBg } = await detectTerminalBg(palette.bg);
 	const uiTheme = createTheme(terminalBg);
@@ -466,6 +463,7 @@ async function runAuthScreen(): Promise<boolean> {
 		<ThemeProvider value={uiTheme}>
 			<AuthScreen
 				keys={new ProviderKeyController()}
+				warnings={interactiveRenderConfig.warnings}
 				onKeySaved={() => {
 					didLogin = true;
 				}}
@@ -477,13 +475,10 @@ async function runAuthScreen(): Promise<boolean> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(
-		app,
-		interactiveRenderOptions({
-			exitOnCtrlC: true,
-			maxFps: resolveInteractiveRenderConfig().maxFps,
-		}),
-	);
+	const instance = render(app, {
+		exitOnCtrlC: true,
+		maxFps: interactiveRenderConfig.maxFps,
+	});
 	await instance.waitUntilExit();
 	if (didLogin) {
 		instance.clear();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -431,7 +431,10 @@ async function main(): Promise<void> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(app, interactiveRenderOptions(false));
+	const instance = render(
+		app,
+		interactiveRenderOptions({ exitOnCtrlC: false }),
+	);
 
 	try {
 		await instance.waitUntilExit();
@@ -460,7 +463,7 @@ async function runAuthScreen(): Promise<boolean> {
 			/>
 		</ThemeProvider>
 	);
-	const instance = render(app, interactiveRenderOptions(true));
+	const instance = render(app, interactiveRenderOptions({ exitOnCtrlC: true }));
 	await instance.waitUntilExit();
 	if (didLogin) {
 		instance.clear();

--- a/src/state/Store.ts
+++ b/src/state/Store.ts
@@ -561,7 +561,10 @@ function appendAssistantDelta(
 		...state,
 		render: {
 			...state.render,
-			staticItems: [...state.render.staticItems, ...chunks],
+			staticItems:
+				chunks.length === 0
+					? state.render.staticItems
+					: [...state.render.staticItems, ...chunks],
 			liveItems: state.render.liveItems.filter(
 				(item) => item.id !== assistantLiveId(flushedStream.messageId),
 			),

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -157,7 +157,10 @@ import { TerminalSizeProvider } from "./hooks/TerminalSizeContext.tsx";
 import { useAgent } from "./hooks/useAgent.ts";
 import { useLspToggle } from "./hooks/useLspToggle.ts";
 import { useResizeStabilizer } from "./hooks/useResizeStabilizer.ts";
-import { useStableTranscriptLayout } from "./hooks/useStableTranscriptLayout.ts";
+import {
+	useStableStaticBanner,
+	useStableTranscriptLayout,
+} from "./hooks/useStableTranscriptLayout.ts";
 import { useStartupPickerPreload } from "./hooks/useStartupPickerPreload.ts";
 import { VerboseProvider } from "./hooks/VerboseContext.tsx";
 import type { PromptHistoryState, QueuedPromptItem } from "./input/types.ts";
@@ -1691,6 +1694,15 @@ export function App({
 		}),
 		agent.state.render.generation,
 	);
+	const staticGeneration =
+		agent.state.render.generation +
+		resize.resizeEpoch +
+		verboseEpoch +
+		updateEpoch;
+	const staticBanner = useStableStaticBanner(
+		showBanner ? banner : null,
+		staticGeneration,
+	);
 	const liveItems = compactLiveTranscriptItems(agent.state.render.liveItems);
 
 	if (resize.isResizing) {
@@ -1703,13 +1715,8 @@ export function App({
 				<Box flexDirection="column">
 					<StaticTranscript
 						items={transcriptLayout.staticItems}
-						generation={
-							agent.state.render.generation +
-							resize.resizeEpoch +
-							verboseEpoch +
-							updateEpoch
-						}
-						banner={showBanner ? banner : null}
+						generation={staticGeneration}
+						banner={staticBanner}
 					/>
 					<MessageList
 						items={[...transcriptLayout.responsiveItems, ...liveItems]}

--- a/src/ui/AuthScreen.tsx
+++ b/src/ui/AuthScreen.tsx
@@ -53,6 +53,7 @@ export function AuthScreen({
 	onLogin,
 	keys,
 	onKeySaved,
+	warnings = [],
 }: AuthScreenProps): React.ReactElement {
 	const app = useApp();
 	const actions = keys ? AUTH_ACTIONS_WITH_BYOK : AUTH_ACTIONS_LOGIN_ONLY;
@@ -199,6 +200,11 @@ export function AuthScreen({
 	return (
 		<Box flexDirection="column">
 			<AuthPrompt selected={selected} columns={columns} />
+			{warnings.map((warning) => (
+				<Text key={warning} color={theme.warning}>
+					{warning}
+				</Text>
+			))}
 			{error ? <Text color={theme.error}>{error}</Text> : null}
 		</Box>
 	);

--- a/src/ui/AuthScreenTypes.ts
+++ b/src/ui/AuthScreenTypes.ts
@@ -15,6 +15,7 @@ export type AuthLoginHandler = (
 
 export interface AuthScreenProps {
 	onLogin: AuthLoginHandler;
+	warnings?: readonly string[];
 	/** Drives the BYOK branch; omit to offer Backboard sign-in only. */
 	keys?: ProviderKeyController;
 	/** Called once a provider key is saved, so startup can retry with it. */

--- a/src/ui/components/StaticTranscript.tsx
+++ b/src/ui/components/StaticTranscript.tsx
@@ -7,16 +7,18 @@ import type { RenderTranscriptItem, RunStatus } from "../../state/AppState.ts";
 import { Banner } from "./Banner.tsx";
 import { Item } from "./MessageList.tsx";
 
+export interface StaticTranscriptBanner {
+	status: RunStatus;
+	model: string;
+	cwd: string;
+	usage: UsageInfo;
+	update?: StartupUpdateInfo | null;
+}
+
 interface Props {
 	items: RenderTranscriptItem[];
 	generation: number;
-	banner: {
-		status: RunStatus;
-		model: string;
-		cwd: string;
-		usage: UsageInfo;
-		update?: StartupUpdateInfo | null;
-	} | null;
+	banner: StaticTranscriptBanner | null;
 }
 
 type StaticTranscriptItem =
@@ -54,7 +56,10 @@ function StaticTranscriptComponent({
 		: items;
 
 	return (
-		<Static key={generation} items={staticItems}>
+		<Static
+			key={`${generation}:${banner === null ? "plain" : "banner"}`}
+			items={staticItems}
+		>
 			{(item) =>
 				item.kind === "banner" ? (
 					<Banner
@@ -73,20 +78,4 @@ function StaticTranscriptComponent({
 	);
 }
 
-export function shouldReuseStaticTranscript(
-	previous: Props,
-	next: Props,
-): boolean {
-	if (previous.generation !== next.generation) return false;
-	if (previous.items.length !== next.items.length) return false;
-	// <Static> is append-only. Banner changes are picked up when generation
-	// changes and the transcript is intentionally reprinted. During ordinary
-	// App updates, avoid touching Ink's internal_static node because that
-	// bypasses maxFps and forces an immediate render.
-	return previous.items.every((item, index) => item === next.items[index]);
-}
-
-export const StaticTranscript = memo(
-	StaticTranscriptComponent,
-	shouldReuseStaticTranscript,
-);
+export const StaticTranscript = memo(StaticTranscriptComponent);

--- a/src/ui/components/StaticTranscript.tsx
+++ b/src/ui/components/StaticTranscript.tsx
@@ -1,5 +1,6 @@
 import { Static } from "ink";
 import type React from "react";
+import { memo } from "react";
 import type { UsageInfo } from "../../core/bus/events.ts";
 import type { StartupUpdateInfo } from "../../core/update/startupNotice.ts";
 import type { RenderTranscriptItem, RunStatus } from "../../state/AppState.ts";
@@ -30,7 +31,7 @@ type StaticTranscriptItem =
 			update?: StartupUpdateInfo | null;
 	  };
 
-export function StaticTranscript({
+function StaticTranscriptComponent({
 	items,
 	generation,
 	banner,
@@ -71,3 +72,21 @@ export function StaticTranscript({
 		</Static>
 	);
 }
+
+export function shouldReuseStaticTranscript(
+	previous: Props,
+	next: Props,
+): boolean {
+	if (previous.generation !== next.generation) return false;
+	if (previous.items.length !== next.items.length) return false;
+	// <Static> is append-only. Banner changes are picked up when generation
+	// changes and the transcript is intentionally reprinted. During ordinary
+	// App updates, avoid touching Ink's internal_static node because that
+	// bypasses maxFps and forces an immediate render.
+	return previous.items.every((item, index) => item === next.items[index]);
+}
+
+export const StaticTranscript = memo(
+	StaticTranscriptComponent,
+	shouldReuseStaticTranscript,
+);

--- a/src/ui/components/TranscriptLayout.ts
+++ b/src/ui/components/TranscriptLayout.ts
@@ -11,15 +11,27 @@ export function splitResponsiveTranscript(
 	tailItemCount = RESPONSIVE_TRANSCRIPT_TAIL_ITEMS,
 	minimumStaticItemCount = 0,
 ): TranscriptLayout {
-	const desiredSplitIndex = Math.max(0, items.length - tailItemCount);
-	const splitIndex = Math.min(
+	const splitIndex = responsiveTranscriptSplitIndex(
 		items.length,
-		Math.max(desiredSplitIndex, minimumStaticItemCount),
+		tailItemCount,
+		minimumStaticItemCount,
 	);
 	return {
 		staticItems: items.slice(0, splitIndex),
 		responsiveItems: items.slice(splitIndex),
 	};
+}
+
+export function responsiveTranscriptSplitIndex(
+	itemCount: number,
+	tailItemCount = RESPONSIVE_TRANSCRIPT_TAIL_ITEMS,
+	minimumStaticItemCount = 0,
+): number {
+	const desiredSplitIndex = Math.max(0, itemCount - tailItemCount);
+	return Math.min(
+		itemCount,
+		Math.max(desiredSplitIndex, minimumStaticItemCount),
+	);
 }
 
 export function compactLiveTranscriptItems(

--- a/src/ui/hooks/useStableTranscriptLayout.ts
+++ b/src/ui/hooks/useStableTranscriptLayout.ts
@@ -1,6 +1,7 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import type { RenderTranscriptItem } from "../../state/AppState.ts";
-import { splitResponsiveTranscript } from "../components/TranscriptLayout.ts";
+import type { StaticTranscriptBanner } from "../components/StaticTranscript.tsx";
+import { responsiveTranscriptSplitIndex } from "../components/TranscriptLayout.ts";
 import type { TranscriptLayout } from "../components/TranscriptLayout.types.ts";
 
 export function useStableTranscriptLayout(
@@ -18,11 +19,37 @@ export function useStableTranscriptLayout(
 		staticItemCount.current,
 		items.length,
 	);
-	const layout = splitResponsiveTranscript(
-		items,
+	const splitIndex = responsiveTranscriptSplitIndex(
+		items.length,
 		tailItemCount,
 		minimumStaticItemCount,
 	);
+	const layout = useMemo(
+		() => ({
+			staticItems: items.slice(0, splitIndex),
+			responsiveItems: items.slice(splitIndex),
+		}),
+		[items, splitIndex],
+	);
 	staticItemCount.current = layout.staticItems.length;
 	return layout;
+}
+
+export function useStableStaticBanner(
+	banner: StaticTranscriptBanner | null,
+	generation: number,
+): StaticTranscriptBanner | null {
+	const snapshot = useRef({
+		banner,
+		generation,
+		hasBanner: banner !== null,
+	});
+	const hasBanner = banner !== null;
+	if (
+		snapshot.current.generation !== generation ||
+		snapshot.current.hasBanner !== hasBanner
+	) {
+		snapshot.current = { banner, generation, hasBanner };
+	}
+	return snapshot.current.banner;
 }

--- a/src/ui/renderOptions.ts
+++ b/src/ui/renderOptions.ts
@@ -1,11 +1,39 @@
-export const INTERACTIVE_RENDER_MAX_FPS = 60;
+import type { RenderOptions } from "ink";
 
-export function interactiveRenderOptions(exitOnCtrlC: boolean): {
+const DEFAULT_INTERACTIVE_RENDER_MAX_FPS = 60;
+const MAX_INTERACTIVE_RENDER_MAX_FPS = 120;
+
+interface InteractiveRenderOptionsInput {
 	exitOnCtrlC: boolean;
-	maxFps: number;
-} {
+	env?: Partial<Pick<NodeJS.ProcessEnv, "BACKBOARD_MAX_FPS">>;
+}
+
+type InteractiveRenderOptions = Pick<
+	RenderOptions,
+	"exitOnCtrlC" | "incrementalRendering" | "maxFps"
+>;
+
+export function interactiveRenderOptions({
+	exitOnCtrlC,
+	env,
+}: InteractiveRenderOptionsInput): InteractiveRenderOptions {
+	const maxFpsOverride =
+		env === undefined ? process.env.BACKBOARD_MAX_FPS : env.BACKBOARD_MAX_FPS;
 	return {
 		exitOnCtrlC,
-		maxFps: INTERACTIVE_RENDER_MAX_FPS,
+		incrementalRendering: true,
+		maxFps: resolveInteractiveRenderMaxFps(maxFpsOverride),
 	};
+}
+
+function resolveInteractiveRenderMaxFps(value: string | undefined): number {
+	const normalized = value?.trim();
+	if (!normalized || !/^\d+$/.test(normalized)) {
+		return DEFAULT_INTERACTIVE_RENDER_MAX_FPS;
+	}
+	const parsed = Number(normalized);
+	if (parsed < 1 || parsed > MAX_INTERACTIVE_RENDER_MAX_FPS) {
+		return DEFAULT_INTERACTIVE_RENDER_MAX_FPS;
+	}
+	return parsed;
 }

--- a/src/ui/renderOptions.ts
+++ b/src/ui/renderOptions.ts
@@ -1,29 +1,14 @@
-import type { RenderOptions } from "ink";
+import { truncate } from "../utils/string.ts";
+import { sanitizeForTerminal } from "../utils/terminalSafe.ts";
 
 const DEFAULT_INTERACTIVE_RENDER_MAX_FPS = 30;
 const MIN_INTERACTIVE_RENDER_MAX_FPS = 1;
 const MAX_INTERACTIVE_RENDER_MAX_FPS = 120;
-
-interface InteractiveRenderOptionsInput {
-	exitOnCtrlC: boolean;
-	maxFps: number;
-}
-
-type InteractiveRenderOptions = Pick<RenderOptions, "exitOnCtrlC" | "maxFps">;
-
-export function interactiveRenderOptions({
-	exitOnCtrlC,
-	maxFps,
-}: InteractiveRenderOptionsInput): InteractiveRenderOptions {
-	return {
-		exitOnCtrlC,
-		maxFps,
-	};
-}
+const MAX_RENDER_ENV_VALUE_LENGTH = 120;
 
 export interface InteractiveRenderConfig {
 	maxFps: number;
-	warning?: string;
+	warnings: string[];
 }
 
 export function resolveInteractiveRenderConfig(
@@ -31,12 +16,15 @@ export function resolveInteractiveRenderConfig(
 ): InteractiveRenderConfig {
 	const normalized = value?.trim();
 	if (!normalized) {
-		return { maxFps: DEFAULT_INTERACTIVE_RENDER_MAX_FPS };
+		return { maxFps: DEFAULT_INTERACTIVE_RENDER_MAX_FPS, warnings: [] };
 	}
 	if (!/^-?\d+$/.test(normalized)) {
+		const displayedValue = displayRenderEnvValue(value ?? "");
 		return {
 			maxFps: DEFAULT_INTERACTIVE_RENDER_MAX_FPS,
-			warning: `Invalid BACKBOARD_MAX_FPS "${value}"; using ${DEFAULT_INTERACTIVE_RENDER_MAX_FPS}. Expected an integer from ${MIN_INTERACTIVE_RENDER_MAX_FPS} to ${MAX_INTERACTIVE_RENDER_MAX_FPS}.`,
+			warnings: [
+				`Invalid BACKBOARD_MAX_FPS ${displayedValue}; using ${DEFAULT_INTERACTIVE_RENDER_MAX_FPS}. Expected an integer from ${MIN_INTERACTIVE_RENDER_MAX_FPS} to ${MAX_INTERACTIVE_RENDER_MAX_FPS}.`,
+			],
 		};
 	}
 
@@ -46,10 +34,18 @@ export function resolveInteractiveRenderConfig(
 		Math.max(MIN_INTERACTIVE_RENDER_MAX_FPS, parsed),
 	);
 	if (maxFps !== parsed) {
+		const displayedValue = displayRenderEnvValue(value ?? "");
 		return {
 			maxFps,
-			warning: `BACKBOARD_MAX_FPS "${value}" is outside ${MIN_INTERACTIVE_RENDER_MAX_FPS}-${MAX_INTERACTIVE_RENDER_MAX_FPS}; using ${maxFps}.`,
+			warnings: [
+				`BACKBOARD_MAX_FPS ${displayedValue} is outside ${MIN_INTERACTIVE_RENDER_MAX_FPS}-${MAX_INTERACTIVE_RENDER_MAX_FPS}; using ${maxFps}.`,
+			],
 		};
 	}
-	return { maxFps };
+	return { maxFps, warnings: [] };
+}
+
+function displayRenderEnvValue(value: string): string {
+	const sanitized = sanitizeForTerminal(value).replace(/\s+/g, " ").trim();
+	return JSON.stringify(truncate(sanitized, MAX_RENDER_ENV_VALUE_LENGTH));
 }

--- a/src/ui/renderOptions.ts
+++ b/src/ui/renderOptions.ts
@@ -1,0 +1,11 @@
+export const INTERACTIVE_RENDER_MAX_FPS = 60;
+
+export function interactiveRenderOptions(exitOnCtrlC: boolean): {
+	exitOnCtrlC: boolean;
+	maxFps: number;
+} {
+	return {
+		exitOnCtrlC,
+		maxFps: INTERACTIVE_RENDER_MAX_FPS,
+	};
+}

--- a/src/ui/renderOptions.ts
+++ b/src/ui/renderOptions.ts
@@ -1,39 +1,55 @@
 import type { RenderOptions } from "ink";
 
-const DEFAULT_INTERACTIVE_RENDER_MAX_FPS = 60;
+const DEFAULT_INTERACTIVE_RENDER_MAX_FPS = 30;
+const MIN_INTERACTIVE_RENDER_MAX_FPS = 1;
 const MAX_INTERACTIVE_RENDER_MAX_FPS = 120;
 
 interface InteractiveRenderOptionsInput {
 	exitOnCtrlC: boolean;
-	env?: Partial<Pick<NodeJS.ProcessEnv, "BACKBOARD_MAX_FPS">>;
+	maxFps: number;
 }
 
-type InteractiveRenderOptions = Pick<
-	RenderOptions,
-	"exitOnCtrlC" | "incrementalRendering" | "maxFps"
->;
+type InteractiveRenderOptions = Pick<RenderOptions, "exitOnCtrlC" | "maxFps">;
 
 export function interactiveRenderOptions({
 	exitOnCtrlC,
-	env,
+	maxFps,
 }: InteractiveRenderOptionsInput): InteractiveRenderOptions {
-	const maxFpsOverride =
-		env === undefined ? process.env.BACKBOARD_MAX_FPS : env.BACKBOARD_MAX_FPS;
 	return {
 		exitOnCtrlC,
-		incrementalRendering: true,
-		maxFps: resolveInteractiveRenderMaxFps(maxFpsOverride),
+		maxFps,
 	};
 }
 
-function resolveInteractiveRenderMaxFps(value: string | undefined): number {
+export interface InteractiveRenderConfig {
+	maxFps: number;
+	warning?: string;
+}
+
+export function resolveInteractiveRenderConfig(
+	value = process.env.BACKBOARD_MAX_FPS,
+): InteractiveRenderConfig {
 	const normalized = value?.trim();
-	if (!normalized || !/^\d+$/.test(normalized)) {
-		return DEFAULT_INTERACTIVE_RENDER_MAX_FPS;
+	if (!normalized) {
+		return { maxFps: DEFAULT_INTERACTIVE_RENDER_MAX_FPS };
 	}
+	if (!/^-?\d+$/.test(normalized)) {
+		return {
+			maxFps: DEFAULT_INTERACTIVE_RENDER_MAX_FPS,
+			warning: `Invalid BACKBOARD_MAX_FPS "${value}"; using ${DEFAULT_INTERACTIVE_RENDER_MAX_FPS}. Expected an integer from ${MIN_INTERACTIVE_RENDER_MAX_FPS} to ${MAX_INTERACTIVE_RENDER_MAX_FPS}.`,
+		};
+	}
+
 	const parsed = Number(normalized);
-	if (parsed < 1 || parsed > MAX_INTERACTIVE_RENDER_MAX_FPS) {
-		return DEFAULT_INTERACTIVE_RENDER_MAX_FPS;
+	const maxFps = Math.min(
+		MAX_INTERACTIVE_RENDER_MAX_FPS,
+		Math.max(MIN_INTERACTIVE_RENDER_MAX_FPS, parsed),
+	);
+	if (maxFps !== parsed) {
+		return {
+			maxFps,
+			warning: `BACKBOARD_MAX_FPS "${value}" is outside ${MIN_INTERACTIVE_RENDER_MAX_FPS}-${MAX_INTERACTIVE_RENDER_MAX_FPS}; using ${maxFps}.`,
+		};
 	}
-	return parsed;
+	return { maxFps };
 }

--- a/tests/AuthScreenResize.test.ts
+++ b/tests/AuthScreenResize.test.ts
@@ -8,10 +8,11 @@ import {
 } from "../src/ui/hooks/ResizeStabilizer.constants.ts";
 import { type InkTty, makeInkTty } from "./inkHarness.ts";
 
-function renderAuthScreen(tty: InkTty) {
+function renderAuthScreen(tty: InkTty, warnings: readonly string[] = []) {
 	return render(
 		React.createElement(AuthScreen, {
 			onLogin: () => new Promise<string>(() => {}),
+			warnings,
 		}),
 		{
 			stdout: tty.stdout as unknown as NodeJS.WriteStream,
@@ -25,6 +26,15 @@ function renderAuthScreen(tty: InkTty) {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("AuthScreen resize handling", () => {
+	it("shows interactive render configuration warnings", async () => {
+		const tty = makeInkTty(80, 45);
+		const instance = renderAuthScreen(tty, ["Invalid render setting"]);
+		await sleep(20);
+		instance.unmount();
+
+		expect(tty.written()).toContain("Invalid render setting");
+	});
+
 	it("clears screen and scrollback when the terminal is resized", async () => {
 		const tty = makeInkTty(80, 45);
 		const instance = renderAuthScreen(tty);

--- a/tests/RenderOptions.test.ts
+++ b/tests/RenderOptions.test.ts
@@ -1,19 +1,62 @@
 import { describe, expect, it } from "bun:test";
-import {
-	INTERACTIVE_RENDER_MAX_FPS,
-	interactiveRenderOptions,
-} from "../src/ui/renderOptions.ts";
+import { readFileSync } from "node:fs";
+import { interactiveRenderOptions } from "../src/ui/renderOptions.ts";
 
 describe("interactive render options", () => {
-	it("uses a responsive frame ceiling for each interactive root", () => {
-		expect(INTERACTIVE_RENDER_MAX_FPS).toBe(60);
-		expect(interactiveRenderOptions(false)).toEqual({
+	it("uses incremental rendering with a responsive default ceiling", () => {
+		expect(interactiveRenderOptions({ exitOnCtrlC: false, env: {} })).toEqual({
 			exitOnCtrlC: false,
+			incrementalRendering: true,
 			maxFps: 60,
 		});
-		expect(interactiveRenderOptions(true)).toEqual({
+	});
+
+	it("preserves each root's Ctrl+C behavior", () => {
+		expect(interactiveRenderOptions({ exitOnCtrlC: true, env: {} })).toEqual({
 			exitOnCtrlC: true,
+			incrementalRendering: true,
 			maxFps: 60,
 		});
+	});
+
+	it("accepts bounded integer frame-rate overrides", () => {
+		for (const [value, expected] of [
+			["1", 1],
+			[" 30 ", 30],
+			["120", 120],
+		] as const) {
+			expect(
+				interactiveRenderOptions({
+					exitOnCtrlC: false,
+					env: { BACKBOARD_MAX_FPS: value },
+				}).maxFps,
+			).toBe(expected);
+		}
+	});
+
+	it("falls back for invalid or excessive frame-rate overrides", () => {
+		for (const value of ["0", "-1", "30.5", "fast", "121"]) {
+			expect(
+				interactiveRenderOptions({
+					exitOnCtrlC: false,
+					env: { BACKBOARD_MAX_FPS: value },
+				}).maxFps,
+			).toBe(60);
+		}
+	});
+
+	it("keeps both CLI render roots on the shared configuration", () => {
+		const cliSource = readFileSync(
+			new URL("../src/entrypoints/cli.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(cliSource).toContain(
+			"interactiveRenderOptions({ exitOnCtrlC: false })",
+		);
+		expect(cliSource).toContain(
+			"interactiveRenderOptions({ exitOnCtrlC: true })",
+		);
+		expect(cliSource).not.toContain("maxFps: 12");
 	});
 });

--- a/tests/RenderOptions.test.ts
+++ b/tests/RenderOptions.test.ts
@@ -1,22 +1,29 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { interactiveRenderOptions } from "../src/ui/renderOptions.ts";
+import {
+	interactiveRenderOptions,
+	resolveInteractiveRenderConfig,
+} from "../src/ui/renderOptions.ts";
 
 describe("interactive render options", () => {
-	it("uses incremental rendering with a responsive default ceiling", () => {
-		expect(interactiveRenderOptions({ exitOnCtrlC: false, env: {} })).toEqual({
-			exitOnCtrlC: false,
-			incrementalRendering: true,
-			maxFps: 60,
+	it("uses a balanced default frame ceiling", () => {
+		expect(resolveInteractiveRenderConfig(undefined)).toEqual({
+			maxFps: 30,
 		});
 	});
 
 	it("preserves each root's Ctrl+C behavior", () => {
-		expect(interactiveRenderOptions({ exitOnCtrlC: true, env: {} })).toEqual({
-			exitOnCtrlC: true,
-			incrementalRendering: true,
-			maxFps: 60,
+		expect(
+			interactiveRenderOptions({ exitOnCtrlC: false, maxFps: 30 }),
+		).toEqual({
+			exitOnCtrlC: false,
+			maxFps: 30,
 		});
+		expect(interactiveRenderOptions({ exitOnCtrlC: true, maxFps: 30 })).toEqual(
+			{
+				exitOnCtrlC: true,
+				maxFps: 30,
+			},
+		);
 	});
 
 	it("accepts bounded integer frame-rate overrides", () => {
@@ -25,38 +32,39 @@ describe("interactive render options", () => {
 			[" 30 ", 30],
 			["120", 120],
 		] as const) {
-			expect(
-				interactiveRenderOptions({
-					exitOnCtrlC: false,
-					env: { BACKBOARD_MAX_FPS: value },
-				}).maxFps,
-			).toBe(expected);
+			expect(resolveInteractiveRenderConfig(value)).toEqual({
+				maxFps: expected,
+			});
 		}
 	});
 
-	it("falls back for invalid or excessive frame-rate overrides", () => {
-		for (const value of ["0", "-1", "30.5", "fast", "121"]) {
-			expect(
-				interactiveRenderOptions({
-					exitOnCtrlC: false,
-					env: { BACKBOARD_MAX_FPS: value },
-				}).maxFps,
-			).toBe(60);
-		}
+	it("clamps numeric overrides and explains the adjustment", () => {
+		expect(resolveInteractiveRenderConfig("0")).toEqual({
+			maxFps: 1,
+			warning: 'BACKBOARD_MAX_FPS "0" is outside 1-120; using 1.',
+		});
+		expect(resolveInteractiveRenderConfig("121")).toEqual({
+			maxFps: 120,
+			warning: 'BACKBOARD_MAX_FPS "121" is outside 1-120; using 120.',
+		});
 	});
 
-	it("keeps both CLI render roots on the shared configuration", () => {
-		const cliSource = readFileSync(
-			new URL("../src/entrypoints/cli.tsx", import.meta.url),
-			"utf8",
-		);
+	it("falls back with a warning for malformed overrides", () => {
+		expect(resolveInteractiveRenderConfig("30fps")).toEqual({
+			maxFps: 30,
+			warning:
+				'Invalid BACKBOARD_MAX_FPS "30fps"; using 30. Expected an integer from 1 to 120.',
+		});
+	});
 
-		expect(cliSource).toContain(
-			"interactiveRenderOptions({ exitOnCtrlC: false })",
-		);
-		expect(cliSource).toContain(
-			"interactiveRenderOptions({ exitOnCtrlC: true })",
-		);
-		expect(cliSource).not.toContain("maxFps: 12");
+	it("reads the production environment when no value is passed", () => {
+		const previous = process.env.BACKBOARD_MAX_FPS;
+		process.env.BACKBOARD_MAX_FPS = "45";
+		try {
+			expect(resolveInteractiveRenderConfig()).toEqual({ maxFps: 45 });
+		} finally {
+			if (previous === undefined) delete process.env.BACKBOARD_MAX_FPS;
+			else process.env.BACKBOARD_MAX_FPS = previous;
+		}
 	});
 });

--- a/tests/RenderOptions.test.ts
+++ b/tests/RenderOptions.test.ts
@@ -1,29 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import {
-	interactiveRenderOptions,
-	resolveInteractiveRenderConfig,
-} from "../src/ui/renderOptions.ts";
+import { resolveInteractiveRenderConfig } from "../src/ui/renderOptions.ts";
 
 describe("interactive render options", () => {
 	it("uses a balanced default frame ceiling", () => {
-		expect(resolveInteractiveRenderConfig(undefined)).toEqual({
+		expect(resolveInteractiveRenderConfig("")).toEqual({
 			maxFps: 30,
+			warnings: [],
 		});
-	});
-
-	it("preserves each root's Ctrl+C behavior", () => {
-		expect(
-			interactiveRenderOptions({ exitOnCtrlC: false, maxFps: 30 }),
-		).toEqual({
-			exitOnCtrlC: false,
-			maxFps: 30,
-		});
-		expect(interactiveRenderOptions({ exitOnCtrlC: true, maxFps: 30 })).toEqual(
-			{
-				exitOnCtrlC: true,
-				maxFps: 30,
-			},
-		);
 	});
 
 	it("accepts bounded integer frame-rate overrides", () => {
@@ -34,6 +17,7 @@ describe("interactive render options", () => {
 		] as const) {
 			expect(resolveInteractiveRenderConfig(value)).toEqual({
 				maxFps: expected,
+				warnings: [],
 			});
 		}
 	});
@@ -41,27 +25,44 @@ describe("interactive render options", () => {
 	it("clamps numeric overrides and explains the adjustment", () => {
 		expect(resolveInteractiveRenderConfig("0")).toEqual({
 			maxFps: 1,
-			warning: 'BACKBOARD_MAX_FPS "0" is outside 1-120; using 1.',
+			warnings: ['BACKBOARD_MAX_FPS "0" is outside 1-120; using 1.'],
 		});
 		expect(resolveInteractiveRenderConfig("121")).toEqual({
 			maxFps: 120,
-			warning: 'BACKBOARD_MAX_FPS "121" is outside 1-120; using 120.',
+			warnings: ['BACKBOARD_MAX_FPS "121" is outside 1-120; using 120.'],
 		});
 	});
 
 	it("falls back with a warning for malformed overrides", () => {
 		expect(resolveInteractiveRenderConfig("30fps")).toEqual({
 			maxFps: 30,
-			warning:
+			warnings: [
 				'Invalid BACKBOARD_MAX_FPS "30fps"; using 30. Expected an integer from 1 to 120.',
+			],
 		});
+	});
+
+	it("sanitizes and bounds malformed values before warning", () => {
+		const result = resolveInteractiveRenderConfig(
+			`\u001B]0;pwned\u0007${"x".repeat(200)}\nnext`,
+		);
+
+		expect(result.maxFps).toBe(30);
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).not.toContain("\u001B");
+		expect(result.warnings[0]).not.toContain("\u0007");
+		expect(result.warnings[0]).not.toContain("\n");
+		expect(result.warnings[0]?.length ?? 0).toBeLessThan(220);
 	});
 
 	it("reads the production environment when no value is passed", () => {
 		const previous = process.env.BACKBOARD_MAX_FPS;
 		process.env.BACKBOARD_MAX_FPS = "45";
 		try {
-			expect(resolveInteractiveRenderConfig()).toEqual({ maxFps: 45 });
+			expect(resolveInteractiveRenderConfig()).toEqual({
+				maxFps: 45,
+				warnings: [],
+			});
 		} finally {
 			if (previous === undefined) delete process.env.BACKBOARD_MAX_FPS;
 			else process.env.BACKBOARD_MAX_FPS = previous;

--- a/tests/RenderOptions.test.ts
+++ b/tests/RenderOptions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import {
+	INTERACTIVE_RENDER_MAX_FPS,
+	interactiveRenderOptions,
+} from "../src/ui/renderOptions.ts";
+
+describe("interactive render options", () => {
+	it("uses a responsive frame ceiling for each interactive root", () => {
+		expect(INTERACTIVE_RENDER_MAX_FPS).toBe(60);
+		expect(interactiveRenderOptions(false)).toEqual({
+			exitOnCtrlC: false,
+			maxFps: 60,
+		});
+		expect(interactiveRenderOptions(true)).toEqual({
+			exitOnCtrlC: true,
+			maxFps: 60,
+		});
+	});
+});

--- a/tests/StaticTranscript.test.tsx
+++ b/tests/StaticTranscript.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { Box, render, Text } from "ink";
+import type React from "react";
+import type { RenderTranscriptItem } from "../src/state/AppState.ts";
+import {
+	StaticTranscript,
+	shouldReuseStaticTranscript,
+} from "../src/ui/components/StaticTranscript.tsx";
+import { makeInkTty } from "./inkHarness.ts";
+
+const firstItem: RenderTranscriptItem = {
+	kind: "notice",
+	id: "notice-1",
+	level: "info",
+	text: "first static item",
+};
+const secondItem: RenderTranscriptItem = {
+	kind: "notice",
+	id: "notice-2",
+	level: "info",
+	text: "second static item",
+};
+
+describe("StaticTranscript", () => {
+	it("reuses the append-only subtree until its items or generation change", () => {
+		const previous = {
+			items: [firstItem],
+			generation: 1,
+			banner: null,
+		};
+
+		expect(
+			shouldReuseStaticTranscript(previous, {
+				...previous,
+				items: [...previous.items],
+			}),
+		).toBe(true);
+		expect(
+			shouldReuseStaticTranscript(previous, {
+				...previous,
+				items: [firstItem, secondItem],
+			}),
+		).toBe(false);
+		expect(
+			shouldReuseStaticTranscript(previous, {
+				...previous,
+				generation: 2,
+			}),
+		).toBe(false);
+	});
+
+	it("keeps dynamic updates behind Ink's frame throttle", async () => {
+		const tty = makeInkTty(80, 12);
+		let renderCount = 0;
+		const frame = (tick: number): React.ReactElement => (
+			<Box flexDirection="column">
+				<StaticTranscript items={[firstItem]} generation={1} banner={null} />
+				<Text>{`${tick}\n`.repeat(20)}</Text>
+			</Box>
+		);
+		const instance = render(frame(0), {
+			stdout: tty.stdout as unknown as NodeJS.WriteStream,
+			stdin: tty.stdin,
+			exitOnCtrlC: false,
+			maxFps: 5,
+			patchConsole: false,
+			onRender: () => {
+				renderCount += 1;
+			},
+		});
+
+		try {
+			await instance.waitUntilRenderFlush();
+			const initialRenderCount = renderCount;
+			for (let tick = 1; tick <= 20; tick += 1) {
+				instance.rerender(frame(tick));
+			}
+			await Bun.sleep(50);
+
+			expect(renderCount - initialRenderCount).toBeLessThanOrEqual(2);
+		} finally {
+			instance.unmount();
+		}
+	});
+});

--- a/tests/StaticTranscript.test.tsx
+++ b/tests/StaticTranscript.test.tsx
@@ -4,8 +4,12 @@ import type React from "react";
 import type { RenderTranscriptItem } from "../src/state/AppState.ts";
 import {
 	StaticTranscript,
-	shouldReuseStaticTranscript,
+	type StaticTranscriptBanner,
 } from "../src/ui/components/StaticTranscript.tsx";
+import {
+	useStableStaticBanner,
+	useStableTranscriptLayout,
+} from "../src/ui/hooks/useStableTranscriptLayout.ts";
 import { makeInkTty } from "./inkHarness.ts";
 
 const firstItem: RenderTranscriptItem = {
@@ -14,56 +18,65 @@ const firstItem: RenderTranscriptItem = {
 	level: "info",
 	text: "first static item",
 };
-const secondItem: RenderTranscriptItem = {
-	kind: "notice",
-	id: "notice-2",
-	level: "info",
-	text: "second static item",
+const staticItems = [firstItem];
+const banner: StaticTranscriptBanner = {
+	status: "idle",
+	model: "test/model",
+	cwd: "/tmp/project",
+	usage: {},
 };
 
 describe("StaticTranscript", () => {
-	it("reuses the append-only subtree until its items or generation change", () => {
-		const previous = {
-			items: [firstItem],
-			generation: 1,
-			banner: null,
-		};
+	it("prints a banner that appears after a generation reset", async () => {
+		const tty = makeInkTty(80, 24);
+		const instance = render(
+			<StaticFrame items={[]} generation={2} banner={null} />,
+			renderOptions(tty),
+		);
 
-		expect(
-			shouldReuseStaticTranscript(previous, {
-				...previous,
-				items: [...previous.items],
-			}),
-		).toBe(true);
-		expect(
-			shouldReuseStaticTranscript(previous, {
-				...previous,
-				items: [firstItem, secondItem],
-			}),
-		).toBe(false);
-		expect(
-			shouldReuseStaticTranscript(previous, {
-				...previous,
-				generation: 2,
-			}),
-		).toBe(false);
+		try {
+			await instance.waitUntilRenderFlush();
+			instance.rerender(
+				<StaticFrame items={[]} generation={2} banner={banner} />,
+			);
+			await instance.waitUntilRenderFlush();
+
+			expect(tty.written()).toContain("Backboard CLI is ready");
+		} finally {
+			instance.unmount();
+		}
+	});
+
+	it("does not lose the next item after removing a banner", async () => {
+		const tty = makeInkTty(80, 24);
+		const instance = render(
+			<StaticFrame items={[]} generation={1} banner={banner} />,
+			renderOptions(tty),
+		);
+
+		try {
+			await instance.waitUntilRenderFlush();
+			instance.rerender(
+				<StaticFrame items={[]} generation={1} banner={null} />,
+			);
+			await instance.waitUntilRenderFlush();
+			instance.rerender(
+				<StaticFrame items={staticItems} generation={1} banner={null} />,
+			);
+			await instance.waitUntilRenderFlush();
+
+			expect(tty.written()).toContain(firstItem.text);
+		} finally {
+			instance.unmount();
+		}
 	});
 
 	it("keeps dynamic updates behind Ink's frame throttle", async () => {
 		const tty = makeInkTty(80, 12);
 		let renderCount = 0;
-		const frame = (tick: number): React.ReactElement => (
-			<Box flexDirection="column">
-				<StaticTranscript items={[firstItem]} generation={1} banner={null} />
-				<Text>{`${tick}\n`.repeat(20)}</Text>
-			</Box>
-		);
-		const instance = render(frame(0), {
-			stdout: tty.stdout as unknown as NodeJS.WriteStream,
-			stdin: tty.stdin,
-			exitOnCtrlC: false,
+		const instance = render(<TranscriptFrame tick={0} />, {
+			...renderOptions(tty),
 			maxFps: 5,
-			patchConsole: false,
 			onRender: () => {
 				renderCount += 1;
 			},
@@ -73,7 +86,7 @@ describe("StaticTranscript", () => {
 			await instance.waitUntilRenderFlush();
 			const initialRenderCount = renderCount;
 			for (let tick = 1; tick <= 20; tick += 1) {
-				instance.rerender(frame(tick));
+				instance.rerender(<TranscriptFrame tick={tick} />);
 			}
 			await Bun.sleep(50);
 
@@ -83,3 +96,45 @@ describe("StaticTranscript", () => {
 		}
 	});
 });
+
+function TranscriptFrame({ tick }: { tick: number }): React.ReactElement {
+	const layout = useStableTranscriptLayout(staticItems, 0, 1);
+	return (
+		<Box flexDirection="column">
+			<StaticTranscript
+				items={layout.staticItems}
+				generation={1}
+				banner={null}
+			/>
+			<Text>{`${tick}\n`.repeat(20)}</Text>
+		</Box>
+	);
+}
+
+function StaticFrame({
+	items,
+	generation,
+	banner,
+}: {
+	items: RenderTranscriptItem[];
+	generation: number;
+	banner: StaticTranscriptBanner | null;
+}): React.ReactElement {
+	const stableBanner = useStableStaticBanner(banner, generation);
+	return (
+		<StaticTranscript
+			items={items}
+			generation={generation}
+			banner={stableBanner}
+		/>
+	);
+}
+
+function renderOptions(tty: ReturnType<typeof makeInkTty>) {
+	return {
+		stdout: tty.stdout as unknown as NodeJS.WriteStream,
+		stdin: tty.stdin,
+		exitOnCtrlC: false,
+		patchConsole: false,
+	};
+}

--- a/tests/Store.test.ts
+++ b/tests/Store.test.ts
@@ -441,6 +441,18 @@ describe("Store reducer", () => {
 		expect(state.render.assistantStreams[0]?.pendingText).toBe("second");
 	});
 
+	it("preserves static item identity while a delta remains buffered", () => {
+		const state = initialState("gpt-test");
+		const next = reduce(state, {
+			type: "assistant:delta",
+			turnId: "turn_1",
+			messageId: "turn_1:assistant:0",
+			text: "partial",
+		});
+
+		expect(next.render.staticItems).toBe(state.render.staticItems);
+	});
+
 	it("commits long no-newline streaming progressively and bounds the pending tail", () => {
 		let state = initialState("gpt-test");
 		state = reduce(state, {


### PR DESCRIPTION
## Summary

- keep Ink's append-only static transcript subtree out of ordinary React updates so it no longer bypasses frame throttling
- preserve banner insertion/removal semantics across `/resume`, `/new`, transcript resets, and keyed `<Static>` remounts
- stabilize static transcript arrays so steady-state memoization is O(1)
- raise the interactive render ceiling from 12 FPS to a balanced 30 FPS default for the main app and authentication screen
- support a validated `BACKBOARD_MAX_FPS` override from 1 to 120, with sanitized warnings for malformed or clamped values
- suppress interactive-only warnings in headless modes and surface them on the auth screen
- document the FPS override in the README
- add real Ink overflow, banner-transition, environment, auth-warning, and state-identity regression coverage

## Why

Issue #8 reports choppy typing and held-Backspace behavior. The original 12 FPS ceiling contributes visible latency, but profiling also found that rerendering `StaticTranscript` marked Ink's internal static node dirty and took an immediate-render path that bypassed `maxFps` entirely.

Memoizing stable append-only inputs makes the throttle effective. Banner presence is included in the keyed static identity so `/resume` → `/new` and banner removal cannot lose output through Ink's retained static index. A 30 FPS default then lowers worst-case visual latency from roughly 84 ms to 34 ms without allowing the terminal-output volume of a 60 FPS default. Faster local terminals can opt into 60 or 120 FPS with `BACKBOARD_MAX_FPS`.

Large pastes continue to use compact previews, and image/file attachments retain their existing asynchronous chip paths.

## Validation

- `bun run validate`
  - 1,367 passed
  - 3 skipped
  - 0 failed
- `BACKBOARD_MAX_FPS=15 bun test tests/RenderOptions.test.ts`
  - 6 passed
- real Ink overflow regression verifies dynamic updates remain behind the configured frame throttle
- banner insertion/removal regressions verify no session card or transcript item is lost
- interactive `tuistory` smoke test with the 30 FPS default

Fixes #8
