### PR TITLE
Add custom sub-agent registry with background execution and time budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,11 @@ Sub-agents cannot prompt you, so they never receive the `ask_user`, `browser`,
 or `computer` tools. Nesting is opt-in: an agent that sets `tools` must include
 `agent` to spawn sub-agents of its own, and nesting stops at two levels deep.
 
+An `rlm` agent has no tools to allow or deny, so `tools` and `disallowedTools`
+do not apply to it. The rest do: its body prefixes the prompts driving the REPL
+loop (but not the `llm_query` calls the loop's own code makes), `model` picks
+the model for those turns, and `maxRounds` caps REPL iterations.
+
 ### Time budgets
 
 `timeoutMs` bounds a single run. Exceeding it never throws the work away.
@@ -372,14 +377,16 @@ Its transcript so far is at .backboard/sessions/<id>/agents/<call>/client.jsonl
 — read that to see where it is.
 ```
 
-Where a handoff is impossible — a nested sub-agent, or a headless run, neither
-of which has anywhere to deliver a later report — expiry instead stops the run
+Where a handoff is impossible — a nested sub-agent, a headless run, or an agent
+that was already launched with `background: true` — expiry instead stops the run
 and spends one short tool-less turn asking what it established, returning
-`status: timed_out` with a partial answer.
+`status: timed_out` with a partial answer. For a background agent the budget is
+the only wall-clock bound it has, since nothing else is waiting on it, so it is
+enforced rather than waived.
 
-Inside a chain that already moved to the background, budgets stop applying
-entirely: nothing is waiting, so a nested run finishes and reports to its parent
-normally. `maxRounds` still bounds it.
+Below a run that moved to the background, budgets stop applying entirely:
+nothing is waiting on those nested runs, so each finishes and reports to its
+parent normally. `maxRounds` still bounds them.
 
 A budget is separate from `maxRounds`: rounds bound how many times the agent may
 call tools, the budget bounds wall-clock time. Rounds always end a run; the
@@ -416,8 +423,11 @@ Details worth knowing:
   anything you type, so a finished agent can never talk over you. If the session
   is idle when one finishes, it starts a turn on its own.
 - **Cancelling the foreground does not kill them.** Background agents run on
-  their own cancellation signal. They are stopped when you start a new thread or
-  exit.
+  their own cancellation signal. They are stopped when you start a new thread,
+  resume another session, or exit.
+- **`timeoutMs` still applies to them.** Nothing is waiting on a background
+  agent, so its budget is what stops it running forever; on expiry it reports
+  the partial progress it has.
 - **Only top-level spawns go to the background.** A sub-agent that spawns
   another one runs it inline regardless of the flag, so no agent is left without
   someone to report to.

--- a/README.md
+++ b/README.md
@@ -356,14 +356,30 @@ or `computer` tools. Nesting is opt-in: an agent that sets `tools` must include
 
 ### Time budgets
 
-`timeoutMs` bounds a single run. When it expires the agent is not simply
-killed — it is asked, in one short final turn with no tools, to report what it
-established before running out. You get a partial answer with `status:
-timed_out` rather than nothing.
+`timeoutMs` bounds a single run. Exceeding it never throws the work away.
+
+For a top-level sub-agent, the budget expiring means the run **moves to the
+background and keeps going**. The tool returns immediately with a run id and the
+path to that agent's transcript, and the report arrives as its own turn once it
+finishes. This matters because a budget usually expires on a task that is merely
+slow — stopping it there would discard real progress and invite the agent to
+start the same work over.
+
+```text
+The sub-agent exceeded its time budget but is STILL RUNNING in the background
+(id: bg_7d8405b0). It has not failed and its work is not lost.
+Its transcript so far is at .backboard/sessions/<id>/agents/<call>/client.jsonl
+— read that to see where it is.
+```
+
+Where a handoff is impossible — a nested sub-agent, or a headless run, neither
+of which has anywhere to deliver a later report — expiry instead stops the run
+and spends one short tool-less turn asking what it established, returning
+`status: timed_out` with a partial answer.
 
 A budget is separate from `maxRounds`: rounds bound how many times the agent may
-call tools, the budget bounds wall-clock time, and whichever is reached first
-ends the run.
+call tools, the budget bounds wall-clock time. Rounds always end a run; the
+budget ends the *waiting*, not necessarily the work.
 
 ### Background agents
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ R-CLI keeps user credentials separate from project state.
 | `<repo-root>/.backboard/settings.json` | Project permission policy                         |
 | `<repo-root>/.backboard/mcp.json`      | Shareable project MCP configuration               |
 | `<repo-root>/.backboard/hooks.json`    | Shareable project hook configuration              |
+| `<repo-root>/.backboard/agents/`       | Shareable project sub-agent definitions           |
+| `~/.backboard/agents/`                 | Personal sub-agent definitions                    |
 | `<cwd>/.backboard/sessions/`           | Session logs, BYOK conversations, and checkpoints |
 | `<cwd>/.agents/skills/`                | Project skills                                    |
 | `~/.agents/skills/`                    | Personal skills                                   |
@@ -307,6 +309,106 @@ For exact formats and precedence, see:
 - [Command and configuration reference](https://docs.backboard.io/cli/reference)
 - [MCP servers and hooks](https://docs.backboard.io/cli/mcp)
 - [Skills and discovery](https://docs.backboard.io/cli/skills)
+
+## Custom sub-agents
+
+The agent delegates scoped work to sub-agents through the `Agent` tool. Each
+sub-agent runs with its own context and returns only a final report, so its
+intermediate tool calls never enter the main session.
+
+Define your own by adding a Markdown file to `.backboard/agents/`. The YAML
+frontmatter configures the agent; the body becomes its system prompt.
+
+```markdown
+---
+description: Deep-dives one question, read-only.
+tools: [read, grep, glob, execute]
+model: anthropic/claude-opus-5
+maxRounds: 30
+---
+
+You are a research sub-agent. Never modify files.
+Report findings as file paths with a one-line summary each.
+```
+
+Save that as `.backboard/agents/researcher.md` and the agent can call it with
+`subagent_type: "researcher"`.
+
+| Field             | Default          | Purpose                                                       |
+| ----------------- | ---------------- | ------------------------------------------------------------- |
+| `description`     | required         | Shown to the model when it picks an agent                     |
+| `name`            | filename         | Lowercase letters, digits, and hyphens                        |
+| `mode`            | `worker`         | `worker` uses tools; `rlm` analyzes input in a JavaScript REPL |
+| `tools`           | all delegatable  | Allowlist of tool names                                       |
+| `disallowedTools` | none             | Tool names to remove                                          |
+| `model`           | inherits session | `provider/model`, or `inherit`                                |
+| `maxRounds`       | `20`             | Tool rounds before the sub-agent is stopped                   |
+| `timeoutMs`       | none             | Wall-clock budget — see "Time budgets" below                  |
+| `background`      | `false`          | Run past the current turn — see "Background agents" below     |
+
+Project files take precedence over personal ones, and both override the
+built-in `worker` and `rlm` agents if they reuse those names. Files that fail
+validation are skipped with a startup warning rather than blocking the session.
+
+Sub-agents cannot prompt you, so they never receive the `ask_user`, `browser`,
+or `computer` tools. Nesting is opt-in: an agent that sets `tools` must include
+`agent` to spawn sub-agents of its own, and nesting stops at two levels deep.
+
+### Time budgets
+
+`timeoutMs` bounds a single run. When it expires the agent is not simply
+killed — it is asked, in one short final turn with no tools, to report what it
+established before running out. You get a partial answer with `status:
+timed_out` rather than nothing.
+
+A budget is separate from `maxRounds`: rounds bound how many times the agent may
+call tools, the budget bounds wall-clock time, and whichever is reached first
+ends the run.
+
+### Background agents
+
+An agent with `background: true` does not block the turn that spawned it. The
+spawn returns immediately, the agent keeps working, and when it finishes its
+report is delivered into the session as a new turn.
+
+```markdown
+---
+description: Watches a long build and reports the outcome.
+tools: [read, grep, execute]
+background: true
+timeoutMs: 900000
+---
+
+Run the build, wait for it, and report pass/fail with the failing output.
+```
+
+While background agents run, the status bar lists them:
+
+```
+✦ Auto mode · (shift+tab to cycle) · anthropic/claude-opus-5 · 2 agents running
+  ↳ watcher   1m20s  run the build and report the outcome
+  ↳ reviewer  0m14s  review the diff on this branch
+```
+
+Details worth knowing:
+
+- **Your input always wins.** Reports are queued at a lower priority than
+  anything you type, so a finished agent can never talk over you. If the session
+  is idle when one finishes, it starts a turn on its own.
+- **Cancelling the foreground does not kill them.** Background agents run on
+  their own cancellation signal. They are stopped when you start a new thread or
+  exit.
+- **Only top-level spawns go to the background.** A sub-agent that spawns
+  another one runs it inline regardless of the flag, so no agent is left without
+  someone to report to.
+- **`/undo` does not cover them.** A background agent outlives the checkpoint of
+  the turn that spawned it, so its file edits are deliberately not journaled
+  there rather than being written into an already-finalized checkpoint. Prefer
+  read-only tools for background agents that you do not want to review by hand.
+- **At most four run at once**; further background spawns queue.
+- **`--print` and `--format json` ignore the flag.** A headless run exits after
+  one prompt, so background agents there would be cancelled before reporting;
+  they run inline instead and the answer includes their work.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Save that as `.backboard/agents/researcher.md` and the agent can call it with
 | `model`           | inherits session | `provider/model`, or `inherit`                                |
 | `maxRounds`       | `20`             | Tool rounds before the sub-agent is stopped                   |
 | `timeoutMs`       | none             | Wall-clock budget — see "Time budgets" below                  |
-| `background`      | `false`          | Run past the current turn — see "Background agents" below     |
+| `background`      | `false`          | Run past the current turn — worker agents only, see below      |
 
 Project files take precedence over personal ones, and both override the
 built-in `worker` and `rlm` agents if they reuse those names. Files that fail
@@ -376,6 +376,10 @@ Where a handoff is impossible — a nested sub-agent, or a headless run, neither
 of which has anywhere to deliver a later report — expiry instead stops the run
 and spends one short tool-less turn asking what it established, returning
 `status: timed_out` with a partial answer.
+
+Inside a chain that already moved to the background, budgets stop applying
+entirely: nothing is waiting, so a nested run finishes and reports to its parent
+normally. `maxRounds` still bounds it.
 
 A budget is separate from `maxRounds`: rounds bound how many times the agent may
 call tools, the budget bounds wall-clock time. Rounds always end a run; the

--- a/README.md
+++ b/README.md
@@ -425,7 +425,9 @@ Details worth knowing:
   the turn that spawned it, so its file edits are deliberately not journaled
   there rather than being written into an already-finalized checkpoint. Prefer
   read-only tools for background agents that you do not want to review by hand.
-- **At most four run at once**; further background spawns queue.
+- **At most four *launched* background agents run at once**; further ones queue.
+  A run that reaches the background by exceeding its budget was already going, so
+  it is not throttled — the cap bounds what is started, not what is adopted.
 - **`--print` and `--format json` ignore the flag.** A headless run exits after
   one prompt, so background agents there would be cancelled before reporting;
   they run inline instead and the answer includes their work.

--- a/src/config/BackboardConfigTypes.ts
+++ b/src/config/BackboardConfigTypes.ts
@@ -13,6 +13,18 @@ export interface BackboardConfigFile {
 	memoryProfile?: MemoryProfile;
 	notify?: boolean;
 	verbose?: boolean;
+	/** Expert mode: implementation runs on `model`, planning stays on `/model`. */
+	expert?: ExpertConfig;
+}
+
+export interface ExpertConfig {
+	enabled: boolean;
+	/** Remembered across an off/on cycle, so the picker only runs once. */
+	model?: {
+		provider: string;
+		model: string;
+	};
+	thinking?: ThinkingIntent | null;
 }
 
 export interface LoadEnvOptions {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -160,10 +160,7 @@ export class Config {
 		const expertBackendMissing =
 			expert?.enabled === true &&
 			expertModel !== null &&
-			this.auth.backboard === null &&
-			!this.auth.providerKeys.some(
-				(entry) => entry.provider === expertModel.provider,
-			);
+			!this.hasBackendFor(expertModel);
 		this.expertEnabled = (expert?.enabled ?? false) && !expertBackendMissing;
 		this.expertModelRef = expertModel;
 		this.expertModelProfile = expertModel
@@ -480,6 +477,10 @@ export class Config {
 		return this.auth.providerKeys.some((entry) => entry.provider === provider);
 	}
 
+	private hasBackendFor(model: ModelRef): boolean {
+		return this.hasBackboardAuth || this.hasProviderKeyFor(model.provider);
+	}
+
 	get hasBackendForCurrentModel(): boolean {
 		return (
 			this.hasBackboardAuth ||
@@ -498,6 +499,13 @@ export class Config {
 		const next = this.auth.backboard ?? anonymousEnv();
 		this.env.apiKey = next.apiKey;
 		this.env.apiUrl = next.apiUrl;
+		if (
+			this.expertEnabled &&
+			this.expertModelRef &&
+			!this.hasBackendFor(this.expertModelRef)
+		) {
+			this.expertEnabled = false;
+		}
 		return this.auth;
 	}
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -375,59 +375,77 @@ export class Config {
 		if ("thinking" in next) this.expertThinking = next.thinking;
 	}
 
+	private saveQueue: Promise<void> = Promise.resolve();
+
+	private enqueueSave(op: () => Promise<void>): Promise<void> {
+		const next = this.saveQueue.then(op);
+		this.saveQueue = next.catch(() => undefined);
+		return next;
+	}
+
 	async saveRuntimeSelection(): Promise<void> {
-		const existing = readBackboardConfig(this.persistedConfigHomeDir);
-		await saveBackboardConfig(
-			{
-				...existing,
-				...(this.flags.model === undefined ? { model: this.currentModel } : {}),
-				...(this.flags.thinking === undefined
-					? { thinking: this.currentThinking }
-					: {}),
-				...(this.flags.memory === undefined
-					? { memory: this.currentMemory }
-					: {}),
-				...(this.flags.memoryProfile === undefined
-					? { memoryProfile: this.currentMemoryProfile }
-					: {}),
-			},
-			this.persistedConfigHomeDir,
-		);
+		await this.enqueueSave(async () => {
+			const existing = readBackboardConfig(this.persistedConfigHomeDir);
+			await saveBackboardConfig(
+				{
+					...existing,
+					...(this.flags.model === undefined
+						? { model: this.currentModel }
+						: {}),
+					...(this.flags.thinking === undefined
+						? { thinking: this.currentThinking }
+						: {}),
+					...(this.flags.memory === undefined
+						? { memory: this.currentMemory }
+						: {}),
+					...(this.flags.memoryProfile === undefined
+						? { memoryProfile: this.currentMemoryProfile }
+						: {}),
+				},
+				this.persistedConfigHomeDir,
+			);
+		});
 	}
 
 	async saveExpertPreference(): Promise<void> {
-		const existing = readBackboardConfig(this.persistedConfigHomeDir);
-		const expert: ExpertConfig = { enabled: this.expertEnabled };
-		if (this.expertModelRef) expert.model = this.expertModelRef;
-		if (this.expertThinking !== undefined) {
-			expert.thinking = this.expertThinking;
-		}
-		await saveBackboardConfig(
-			{ ...existing, expert },
-			this.persistedConfigHomeDir,
-		);
+		await this.enqueueSave(async () => {
+			const existing = readBackboardConfig(this.persistedConfigHomeDir);
+			const expert: ExpertConfig = { enabled: this.expertEnabled };
+			if (this.expertModelRef) expert.model = this.expertModelRef;
+			if (this.expertThinking !== undefined) {
+				expert.thinking = this.expertThinking;
+			}
+			await saveBackboardConfig(
+				{ ...existing, expert },
+				this.persistedConfigHomeDir,
+			);
+		});
 	}
 
 	async saveNotifyPreference(): Promise<void> {
-		const existing = readBackboardConfig(this.persistedConfigHomeDir);
-		await saveBackboardConfig(
-			{
-				...existing,
-				notify: this.notifyEnabled,
-			},
-			this.persistedConfigHomeDir,
-		);
+		await this.enqueueSave(async () => {
+			const existing = readBackboardConfig(this.persistedConfigHomeDir);
+			await saveBackboardConfig(
+				{
+					...existing,
+					notify: this.notifyEnabled,
+				},
+				this.persistedConfigHomeDir,
+			);
+		});
 	}
 
 	async saveVerbosePreference(): Promise<void> {
-		const existing = readBackboardConfig(this.persistedConfigHomeDir);
-		await saveBackboardConfig(
-			{
-				...existing,
-				verbose: this.verboseEnabled,
-			},
-			this.persistedConfigHomeDir,
-		);
+		await this.enqueueSave(async () => {
+			const existing = readBackboardConfig(this.persistedConfigHomeDir);
+			await saveBackboardConfig(
+				{
+					...existing,
+					verbose: this.verboseEnabled,
+				},
+				this.persistedConfigHomeDir,
+			);
+		});
 	}
 
 	get hasBackboardAuth(): boolean {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -202,8 +202,8 @@ export class Config {
 	}
 
 	/** Runtime gate for tools a sub-agent runs; expert mode never narrows it. */
-	isDelegatedToolEnabled(name: string): boolean {
-		return this.delegatedToolPolicy.isRuntimeAllowed(name);
+	isDelegatedToolEnabled(name: string, model?: ModelRef): boolean {
+		return this.delegatedToolPolicyFor(model).isRuntimeAllowed(name);
 	}
 
 	get toolPolicy(): ToolPolicy {
@@ -211,12 +211,18 @@ export class Config {
 	}
 
 	/**
-	 * The sub-agent's policy: it holds the expert model and does implement, so
-	 * it keeps the implementation tools and takes its allow/deny lists from the
-	 * execution model's profile rather than the planner's.
+	 * The sub-agent's policy: it does implement, so it keeps the implementation
+	 * tools and takes its allow/deny lists from the profile of the model it
+	 * runs on rather than the planner's — the execution model by default, or
+	 * the one a custom agent pins with `model:`. A Moonshot agent spawned from
+	 * an OpenAI session must not inherit the OpenAI profile's
+	 * `apply_patch`-instead-of-`edit` shape.
 	 */
-	get delegatedToolPolicy(): ToolPolicy {
-		return this.buildToolPolicy(false, this.executionModelProfile);
+	delegatedToolPolicyFor(model?: ModelRef): ToolPolicy {
+		return this.buildToolPolicy(
+			false,
+			model ? resolveModelProfile(model) : this.executionModelProfile,
+		);
 	}
 
 	private buildToolPolicy(

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -6,6 +6,7 @@ import {
 	NO_CREDENTIALS_MESSAGE,
 	resolveAuth,
 } from "./auth.ts";
+import type { ExpertConfig } from "./BackboardConfigTypes.ts";
 import { readBackboardConfig, saveBackboardConfig } from "./backboardConfig.ts";
 import {
 	DEFAULTS,
@@ -79,6 +80,10 @@ export class Config {
 	private verboseEnabled = true;
 	private readonly currentMemoryProfile: MemoryProfile;
 	private currentThinking: ThinkingIntent | null | undefined;
+	private expertEnabled = false;
+	private expertModelRef: ModelRef | null = null;
+	private expertModelProfile: ModelProfile | null = null;
+	private expertThinking: ThinkingIntent | null | undefined;
 	private readonly currentFinalVerificationNudge: boolean;
 	private readonly excludedToolNames: string[];
 	private readonly persistedConfigHomeDir: string | undefined;
@@ -137,6 +142,13 @@ export class Config {
 				: parseThinking(this.flags.thinking);
 		this.currentFinalVerificationNudge =
 			this.flags.finalVerification ?? DEFAULTS.finalVerificationNudge;
+		const expert = persistedConfig.expert;
+		this.expertEnabled = expert?.enabled ?? false;
+		this.expertModelRef = expert?.model ?? null;
+		this.expertModelProfile = expert?.model
+			? resolveModelProfile(expert.model)
+			: null;
+		this.expertThinking = expert?.thinking;
 		this.notifyEnabled = persistedConfig.notify ?? false;
 		this.verboseEnabled = persistedConfig.verbose ?? true;
 		this.excludedToolNames = parseExcludedTools(this.flags.excludedTools).map(
@@ -189,15 +201,37 @@ export class Config {
 		return this.toolPolicy.isRuntimeAllowed(name);
 	}
 
+	/** Runtime gate for tools a sub-agent runs; expert mode never narrows it. */
+	isDelegatedToolEnabled(name: string): boolean {
+		return this.delegatedToolPolicy.isRuntimeAllowed(name);
+	}
+
 	get toolPolicy(): ToolPolicy {
+		return this.buildToolPolicy(this.isExpertModeEnabled);
+	}
+
+	/**
+	 * The sub-agent's policy: it holds the expert model and does implement, so
+	 * it keeps the implementation tools and takes its allow/deny lists from the
+	 * execution model's profile rather than the planner's.
+	 */
+	get delegatedToolPolicy(): ToolPolicy {
+		return this.buildToolPolicy(false, this.executionModelProfile);
+	}
+
+	private buildToolPolicy(
+		expertModeEnabled: boolean,
+		modelProfile: ModelProfile = this.currentModelProfile,
+	): ToolPolicy {
 		return new ToolPolicy({
 			profileTools: this.profile.tools,
-			modelTools: this.currentModelProfile.tools,
+			modelTools: modelProfile.tools,
 			excludedTools: this.excludedToolNames,
-			modelExcludedTools: this.currentModelProfile.excludedTools,
+			modelExcludedTools: modelProfile.excludedTools,
 			computerUseEnabled: this.computerUseEnabled,
 			browserUseEnabled: this.browserUseEnabled,
 			skillDiscoveryEnabled: this.skillDiscoveryEnabled,
+			expertModeEnabled,
 		});
 	}
 
@@ -278,6 +312,51 @@ export class Config {
 		this.currentThinking = thinking;
 	}
 
+	/** On only once a model is picked — expert mode with no model is a no-op. */
+	get isExpertModeEnabled(): boolean {
+		return this.expertEnabled && this.expertModelRef !== null;
+	}
+
+	get expertModel(): ModelRef | null {
+		return this.expertModelRef;
+	}
+
+	/** The model that implements: the expert pick, else the `/model` selection. */
+	get executionModel(): ModelRef {
+		return this.isExpertModeEnabled && this.expertModelRef
+			? this.expertModelRef
+			: this.currentModel;
+	}
+
+	/** The profile of whichever model implements — it decides that model's tools. */
+	get executionModelProfile(): ModelProfile {
+		return this.isExpertModeEnabled && this.expertModelProfile
+			? this.expertModelProfile
+			: this.currentModelProfile;
+	}
+
+	get executionThinking(): ThinkingIntent | null | undefined {
+		return this.isExpertModeEnabled
+			? this.expertThinking
+			: this.currentThinking;
+	}
+
+	/** Omitting `model` keeps the remembered pick, so off/on needs no re-pick. */
+	setExpertMode(next: {
+		enabled: boolean;
+		model?: ModelRef | null;
+		thinking?: ThinkingIntent | null | undefined;
+	}): void {
+		this.expertEnabled = next.enabled;
+		if (next.model !== undefined) {
+			this.expertModelRef = next.model;
+			this.expertModelProfile = next.model
+				? resolveModelProfile(next.model)
+				: null;
+		}
+		if ("thinking" in next) this.expertThinking = next.thinking;
+	}
+
 	async saveRuntimeSelection(): Promise<void> {
 		const existing = readBackboardConfig(this.persistedConfigHomeDir);
 		await saveBackboardConfig(
@@ -294,6 +373,19 @@ export class Config {
 					? { memoryProfile: this.currentMemoryProfile }
 					: {}),
 			},
+			this.persistedConfigHomeDir,
+		);
+	}
+
+	async saveExpertPreference(): Promise<void> {
+		const existing = readBackboardConfig(this.persistedConfigHomeDir);
+		const expert: ExpertConfig = { enabled: this.expertEnabled };
+		if (this.expertModelRef) expert.model = this.expertModelRef;
+		if (this.expertThinking !== undefined) {
+			expert.thinking = this.expertThinking;
+		}
+		await saveBackboardConfig(
+			{ ...existing, expert },
 			this.persistedConfigHomeDir,
 		);
 	}

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -92,6 +92,7 @@ export class Config {
 	private expertThinking: ThinkingIntent | null | undefined;
 	private readonly currentFinalVerificationNudge: boolean;
 	private readonly excludedToolNames: string[];
+	private readonly configWarnings: string[] = [];
 	private readonly persistedConfigHomeDir: string | undefined;
 
 	constructor(options: ConfigOptions = {}) {
@@ -155,12 +156,27 @@ export class Config {
 		this.currentFinalVerificationNudge =
 			this.flags.finalVerification ?? DEFAULTS.finalVerificationNudge;
 		const expert = persistedConfig.expert;
-		this.expertEnabled = expert?.enabled ?? false;
-		this.expertModelRef = expert?.model ?? null;
-		this.expertModelProfile = expert?.model
-			? resolveModelProfile(expert.model)
+		const expertModel = expert?.model ?? null;
+		const expertBackendMissing =
+			expert?.enabled === true &&
+			expertModel !== null &&
+			this.auth.backboard === null &&
+			!this.auth.providerKeys.some(
+				(entry) => entry.provider === expertModel.provider,
+			);
+		this.expertEnabled = (expert?.enabled ?? false) && !expertBackendMissing;
+		this.expertModelRef = expertModel;
+		this.expertModelProfile = expertModel
+			? resolveModelProfile(expertModel)
 			: null;
 		this.expertThinking = expert?.thinking;
+		if (expertBackendMissing && expertModel) {
+			this.configWarnings.push(
+				`Expert mode is off: no enabled API key for its saved model ${formatModel(
+					expertModel,
+				)}. Pick a reachable model in /settings to turn it back on.`,
+			);
+		}
 		this.notifyEnabled = persistedConfig.notify ?? false;
 		this.verboseEnabled = persistedConfig.verbose ?? true;
 		this.excludedToolNames = parseExcludedTools(this.flags.excludedTools).map(
@@ -446,6 +462,10 @@ export class Config {
 				this.persistedConfigHomeDir,
 			);
 		});
+	}
+
+	get startupWarnings(): readonly string[] {
+		return this.configWarnings;
 	}
 
 	get hasBackboardAuth(): boolean {

--- a/src/config/backboardConfig.ts
+++ b/src/config/backboardConfig.ts
@@ -7,6 +7,7 @@ import type { JsonValue } from "../utils/JsonTypes.ts";
 import type {
 	BackboardConfigFile,
 	BackboardConfigJson,
+	ExpertConfig,
 } from "./BackboardConfigTypes.ts";
 import {
 	parseMemoryMode,
@@ -49,6 +50,7 @@ export function readBackboardConfig(
 			memoryProfile: readMemoryProfileConfig(config),
 			notify: typeof config.notify === "boolean" ? config.notify : undefined,
 			verbose: typeof config.verbose === "boolean" ? config.verbose : undefined,
+			expert: readExpertConfig(config),
 		};
 	} catch (err) {
 		if ((err as { code?: string }).code === "ENOENT") return {};
@@ -59,7 +61,12 @@ export function readBackboardConfig(
 function readModelConfig(
 	config: BackboardConfigJson,
 ): BackboardConfigFile["model"] {
-	const model = config.model;
+	return readModelRef(config.model);
+}
+
+function readModelRef(
+	model: JsonValue | undefined,
+): BackboardConfigFile["model"] {
 	if (typeof model !== "object" || model === null || Array.isArray(model)) {
 		return undefined;
 	}
@@ -99,7 +106,30 @@ function readThinkingConfig(
 	config: BackboardConfigJson,
 ): BackboardConfigFile["thinking"] {
 	if (!("thinking" in config)) return undefined;
-	const { thinking } = config;
+	return readThinkingValue(config.thinking);
+}
+
+function readExpertConfig(
+	config: BackboardConfigJson,
+): BackboardConfigFile["expert"] {
+	const expert = config.expert;
+	if (typeof expert !== "object" || expert === null || Array.isArray(expert)) {
+		return undefined;
+	}
+	const raw = expert as BackboardConfigJson;
+	const parsed: ExpertConfig = { enabled: raw.enabled === true };
+	const model = readModelRef(raw.model);
+	if (model) parsed.model = model;
+	if ("thinking" in raw) {
+		const thinking = readThinkingValue(raw.thinking);
+		if (thinking !== undefined) parsed.thinking = thinking;
+	}
+	return parsed;
+}
+
+function readThinkingValue(
+	thinking: JsonValue | undefined,
+): BackboardConfigFile["thinking"] {
 	if (thinking === null) return null;
 	if (
 		typeof thinking !== "object" ||

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -7,6 +7,7 @@ export const BACKBOARD_CONFIG_DIR_NAME = ".backboard";
 export const MCP_CONFIG_FILE_NAME = "mcp.json";
 export const HOOK_CONFIG_FILE_NAME = "hooks.json";
 export const SESSION_DIR_NAME = "sessions";
+export const AGENTS_DIR_NAME = "agents";
 export const WORKSPACE_CONFIG_FILE_NAME = "workspace.json";
 
 export interface McpConfigPaths {
@@ -117,6 +118,14 @@ export function qProjectHookConfigPath(cwd: string): string {
 
 export function qUserHookConfigPath(homeDir?: string): string {
 	return path.join(qUserConfigDir(homeDir), HOOK_CONFIG_FILE_NAME);
+}
+
+export function qProjectAgentsDir(cwd: string): string {
+	return path.join(qProjectConfigDir(cwd), AGENTS_DIR_NAME);
+}
+
+export function qUserAgentsDir(homeDir?: string): string {
+	return path.join(qUserConfigDir(homeDir), AGENTS_DIR_NAME);
 }
 
 export function qSessionDir(baseDir: string, sessionId: string): string {

--- a/src/config/thinkingRuntime.ts
+++ b/src/config/thinkingRuntime.ts
@@ -1,4 +1,4 @@
-import type { AgentClient } from "../providers/AgentClient.ts";
+import type { AgentClient, RequestOptions } from "../providers/AgentClient.ts";
 import type { Config } from "./Config.ts";
 import type { ThinkingConfig } from "./defaults.ts";
 import { resolveThinking } from "./defaults.ts";
@@ -20,21 +20,24 @@ export async function resolveRuntimeThinking(
 		phase: "initial",
 		requestKind: "user",
 	},
+	options: RequestOptions = {},
 ): Promise<ThinkingConfig | null | undefined> {
-	const resolver = await createRuntimeThinkingResolver(config, client);
+	const resolver = await createRuntimeThinkingResolver(config, client, options);
 	return resolver.resolve(evidence);
 }
 
+/** `options.signal` abandons the metadata lookup; the resolver then has none. */
 export async function createRuntimeThinkingResolver(
 	config: Pick<Config, "model" | "thinkingIntent">,
 	client: Pick<AgentClient, "getModelThinkingMetadata">,
+	options: RequestOptions = {},
 ): Promise<RuntimeThinkingResolver> {
 	const intent = config.thinkingIntent;
 	const model = config.model;
 	const metadata =
 		intent === undefined || intent === null
 			? null
-			: await findModelInfo(client, model).catch(() => null);
+			: await findModelInfo(client, model, options).catch(() => null);
 	return {
 		intent,
 		resolve(evidence) {
@@ -54,6 +57,7 @@ export async function createRuntimeThinkingResolver(
 async function findModelInfo(
 	client: Pick<AgentClient, "getModelThinkingMetadata">,
 	model: { provider: string; model: string },
+	options: RequestOptions,
 ): Promise<ThinkingModelMetadata | null> {
-	return client.getModelThinkingMetadata(model.provider, model.model);
+	return client.getModelThinkingMetadata(model.provider, model.model, options);
 }

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -57,10 +57,11 @@ import type { BackgroundAgentSupervisor } from "./BackgroundAgentSupervisor.ts";
 import { Turn } from "./Turn.ts";
 
 /**
- * How long `dispose()` waits for a cancelled turn to unwind before shutting
- * down anyway. Bounded so an unresponsive tool cannot wedge exit.
+ * How long `dispose()` and a session replacement wait for a cancelled turn to
+ * unwind before proceeding anyway. Bounded so an unresponsive tool cannot
+ * wedge exit, /new or /sessions.
  */
-const SHUTDOWN_SETTLE_MS = 5_000;
+const CANCELLED_TURN_SETTLE_MS = 5_000;
 
 export interface AgentControllerDeps {
 	config: Config;
@@ -196,12 +197,25 @@ export class AgentController {
 	}
 
 	/**
-	 * Stops everything bound to the outgoing session. MUST run before the
-	 * durable session's checkpoint and event-log roots are rotated: a run that
-	 * finishes inside that activation window would otherwise start its report
-	 * turn — and execute its tools — against the replacement storage.
+	 * Stops everything bound to the outgoing session and waits for its turn to
+	 * unwind. MUST be awaited before the durable session's checkpoint and
+	 * event-log roots are rotated: a run that finishes inside that activation
+	 * window would otherwise start its report turn — and execute its tools —
+	 * against the replacement storage. Cancelling only signals, so a turn in an
+	 * abort-insensitive or already-committing tool needs the settle too.
+	 * Background runs are only signalled: their checkpoint access was revoked
+	 * at handoff, so nothing they do afterwards can reach either journal.
 	 */
-	beginSessionReplacement(): void {
+	async beginSessionReplacement(): Promise<void> {
+		this.signalSessionReplacement();
+		await this.settle(CANCELLED_TURN_SETTLE_MS);
+	}
+
+	/**
+	 * The cancellation half, for callers that run after activation and so have
+	 * nothing left to wait for.
+	 */
+	private signalSessionReplacement(): void {
 		// Cancel the runs first: a run cancelled here can never reach the
 		// notifier, and anything that already did is dropped with the queue.
 		this.deps.backgroundSupervisor?.cancelAll();
@@ -215,7 +229,9 @@ export class AgentController {
 	}): void {
 		// A just-finished background run may already have queued its report
 		// turn here; cancel it so it cannot land in the resumed conversation.
-		this.beginSessionReplacement();
+		// Storage has already rotated by this point, so there is nothing to
+		// await — `beginSessionReplacement` guarded that window.
+		this.signalSessionReplacement();
 		this.deps.session.hydrate(input);
 	}
 
@@ -224,7 +240,7 @@ export class AgentController {
 		// report can start one at any moment, and it would keep touching the
 		// tools, logs, and checkpoints being closed here.
 		this.cancel({ clearQueue: true });
-		await this.settle(SHUTDOWN_SETTLE_MS);
+		await this.settle(CANCELLED_TURN_SETTLE_MS);
 		// Pair SessionEnd with SessionStart: only fire it if the session started.
 		if (this.sessionHooksStarted) {
 			await this.runTerminalHook((signal) =>
@@ -699,7 +715,7 @@ export class AgentController {
 		// Background agents were spawned to serve the discarded conversation;
 		// letting them report into the new thread would reference context that
 		// no longer exists.
-		this.beginSessionReplacement();
+		this.signalSessionReplacement();
 		this.deps.session.reset();
 	}
 

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -54,6 +54,12 @@ import { AssistantSessionBinding } from "./AssistantSessionBinding.ts";
 import type { BackgroundAgentSupervisor } from "./BackgroundAgentSupervisor.ts";
 import { Turn } from "./Turn.ts";
 
+/**
+ * How long `dispose()` waits for a cancelled turn to unwind before shutting
+ * down anyway. Bounded so an unresponsive tool cannot wedge exit.
+ */
+const SHUTDOWN_SETTLE_MS = 5_000;
+
 export interface AgentControllerDeps {
 	config: Config;
 	bus: EventBus;
@@ -97,6 +103,8 @@ export class AgentController {
 	private readonly detachSessionProjection: () => void;
 	private readonly queue: QueuedSubmit[] = [];
 	private drainingQueue = false;
+	/** The in-flight drain, so shutdown can await the turn it is running. */
+	private drainPromise: Promise<void> | null = null;
 	private sessionHooksStarted = false;
 
 	constructor(private readonly deps: AgentControllerDeps) {
@@ -185,6 +193,19 @@ export class AgentController {
 		return this.deps.config.isBrowserUseEnabled;
 	}
 
+	/**
+	 * Stops everything bound to the outgoing session. MUST run before the
+	 * durable session's checkpoint and event-log roots are rotated: a run that
+	 * finishes inside that activation window would otherwise start its report
+	 * turn — and execute its tools — against the replacement storage.
+	 */
+	beginSessionReplacement(): void {
+		// Cancel the runs first: a run cancelled here can never reach the
+		// notifier, and anything that already did is dropped with the queue.
+		this.deps.backgroundSupervisor?.cancelAll();
+		this.cancel({ clearQueue: true });
+	}
+
 	hydrateSession(input: {
 		threadId: string;
 		assistantId?: string | null;
@@ -192,12 +213,16 @@ export class AgentController {
 	}): void {
 		// A just-finished background run may already have queued its report
 		// turn here; cancel it so it cannot land in the resumed conversation.
-		this.cancel({ clearQueue: true });
-		this.deps.backgroundSupervisor?.cancelAll();
+		this.beginSessionReplacement();
 		this.deps.session.hydrate(input);
 	}
 
 	async dispose(): Promise<void> {
+		// Teardown must not race a turn that is still unwinding — a background
+		// report can start one at any moment, and it would keep touching the
+		// tools, logs, and checkpoints being closed here.
+		this.cancel({ clearQueue: true });
+		await this.settle(SHUTDOWN_SETTLE_MS);
 		// Pair SessionEnd with SessionStart: only fire it if the session started.
 		if (this.sessionHooksStarted) {
 			await this.runTerminalHook((signal) =>
@@ -270,9 +295,36 @@ export class AgentController {
 		return this.queue.splice(bestIndex, 1)[0];
 	}
 
-	private async drainSubmitQueue(): Promise<void> {
-		if (this.drainingQueue) return;
+	/**
+	 * Resolves once no turn is running and the submit queue is empty, or once
+	 * `timeoutMs` elapses — a tool or stream that ignores its abort signal must
+	 * not be able to hold the process open forever.
+	 */
+	async settle(timeoutMs?: number): Promise<void> {
+		const deadline = timeoutMs === undefined ? null : Date.now() + timeoutMs;
+		while (this.drainPromise) {
+			const drained = this.drainPromise.then(
+				() => true,
+				() => true,
+			);
+			if (deadline === null) {
+				await drained;
+				continue;
+			}
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) return;
+			if (!(await Promise.race([drained, expireAfter(remaining)]))) return;
+		}
+	}
+
+	private drainSubmitQueue(): Promise<void> {
+		if (this.drainingQueue) return this.drainPromise ?? Promise.resolve();
 		this.drainingQueue = true;
+		this.drainPromise = this.drainQueuedSubmits();
+		return this.drainPromise;
+	}
+
+	private async drainQueuedSubmits(): Promise<void> {
 		try {
 			while (this.queue.length > 0) {
 				const queued = this.takeNextSubmit();
@@ -292,6 +344,7 @@ export class AgentController {
 			}
 		} finally {
 			this.drainingQueue = false;
+			this.drainPromise = null;
 			if (this.queue.length > 0) void this.drainSubmitQueue();
 		}
 	}
@@ -634,11 +687,10 @@ export class AgentController {
 
 	/** Cancels any active turn and starts a fresh Backboard thread. */
 	newThread(): void {
-		this.cancel({ clearQueue: true });
 		// Background agents were spawned to serve the discarded conversation;
 		// letting them report into the new thread would reference context that
 		// no longer exists.
-		this.deps.backgroundSupervisor?.cancelAll();
+		this.beginSessionReplacement();
 		this.deps.session.reset();
 	}
 
@@ -731,6 +783,14 @@ export class AgentController {
 			}
 		}
 	}
+}
+
+/** Resolves `false` after `ms`, without holding the event loop open. */
+function expireAfter(ms: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(false), ms);
+		timer.unref?.();
+	});
 }
 
 function formatSubmitError(err: unknown): string {

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -190,6 +190,7 @@ export class AgentController {
 		assistantId?: string | null;
 		messages: readonly Message[];
 	}): void {
+		this.deps.backgroundSupervisor?.cancelAll();
 		this.deps.session.hydrate(input);
 	}
 

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -272,7 +272,7 @@ export class AgentController {
 		try {
 			while (this.queue.length > 0) {
 				const queued = this.takeNextSubmit();
-				if (!queued) continue;
+				if (!queued) break;
 				try {
 					queued.onStart?.();
 					queued.resolve(

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -190,6 +190,9 @@ export class AgentController {
 		assistantId?: string | null;
 		messages: readonly Message[];
 	}): void {
+		// A just-finished background run may already have queued its report
+		// turn here; cancel it so it cannot land in the resumed conversation.
+		this.cancel({ clearQueue: true });
 		this.deps.backgroundSupervisor?.cancelAll();
 		this.deps.session.hydrate(input);
 	}

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -41,14 +41,17 @@ import type { OpenAITool } from "../tools/schema.ts";
 import type { ToolContext } from "../tools/ToolContext.ts";
 import type { ToolRegistry } from "../tools/ToolRegistry.ts";
 import type { ToolScheduler } from "../tools/ToolScheduler.ts";
-import type {
-	CancelOptions,
-	QueuedSubmit,
-	SubmitOptions,
+import {
+	type CancelOptions,
+	type QueuedSubmit,
+	SUBMIT_PRIORITY_ORDER,
+	type SubmitOptions,
+	type SubmitPriority,
 } from "./AgentControllerTypes.ts";
 import { AgentLoopFactory } from "./AgentLoopFactory.ts";
 import { AgentTraceContext } from "./AgentTraceStore.ts";
 import { AssistantSessionBinding } from "./AssistantSessionBinding.ts";
+import type { BackgroundAgentSupervisor } from "./BackgroundAgentSupervisor.ts";
 import { Turn } from "./Turn.ts";
 
 export interface AgentControllerDeps {
@@ -71,6 +74,8 @@ export interface AgentControllerDeps {
 	};
 	onThreadReplaced?: (threadId: string | null) => void;
 	permissions: PermissionContext;
+	/** Stopped when the thread is reset, so stale reports never land. */
+	backgroundSupervisor?: Pick<BackgroundAgentSupervisor, "cancelAll">;
 	/**
 	 * Absolute path to this run's client transcript. Named in the handoff so a
 	 * compressed agent can read back anything the summary left out.
@@ -200,7 +205,7 @@ export class AgentController {
 	}
 
 	async submit(text: string, options: SubmitOptions = {}): Promise<TurnStatus> {
-		return this.enqueueSubmit(text, "back", {
+		return this.enqueueSubmit(text, options.priority ?? "next", {
 			emitUserMessage: options.emitUserMessage ?? true,
 			onStart: options.onStart,
 			attachmentFilePaths: options.attachmentFilePaths,
@@ -210,7 +215,7 @@ export class AgentController {
 
 	async steer(text: string, options: SubmitOptions = {}): Promise<TurnStatus> {
 		const shouldCancelActiveTurn = this.abortController !== null;
-		const run = this.enqueueSubmit(text, "front", {
+		const run = this.enqueueSubmit(text, "now", {
 			emitUserMessage: options.emitUserMessage ?? false,
 			onStart: options.onStart,
 			attachmentFilePaths: options.attachmentFilePaths,
@@ -222,28 +227,43 @@ export class AgentController {
 
 	private enqueueSubmit(
 		text: string,
-		placement: "front" | "back",
+		priority: SubmitPriority,
 		options: Required<Pick<SubmitOptions, "emitUserMessage">> &
 			Pick<SubmitOptions, "onStart" | "attachmentFilePaths" | "displayContent">,
 	): Promise<TurnStatus> {
 		const run = new Promise<TurnStatus>((resolve, reject) => {
-			const queued = {
+			this.queue.push({
 				text,
+				priority,
 				emitUserMessage: options.emitUserMessage,
 				onStart: options.onStart,
 				attachmentFilePaths: options.attachmentFilePaths,
 				displayContent: options.displayContent,
 				resolve,
 				reject,
-			};
-			if (placement === "front") {
-				this.queue.unshift(queued);
-			} else {
-				this.queue.push(queued);
-			}
+			});
 		});
 		void this.drainSubmitQueue();
 		return run;
+	}
+
+	/**
+	 * Removes the highest-priority submission, FIFO within a tier. Selection
+	 * happens at drain time rather than insert time so a `now` steer queued
+	 * behind a `later` report still runs first.
+	 */
+	private takeNextSubmit(): QueuedSubmit | undefined {
+		let bestIndex = -1;
+		let bestRank = Number.POSITIVE_INFINITY;
+		for (const [index, queued] of this.queue.entries()) {
+			const rank = SUBMIT_PRIORITY_ORDER[queued.priority];
+			if (rank < bestRank) {
+				bestIndex = index;
+				bestRank = rank;
+			}
+		}
+		if (bestIndex === -1) return undefined;
+		return this.queue.splice(bestIndex, 1)[0];
 	}
 
 	private async drainSubmitQueue(): Promise<void> {
@@ -251,7 +271,7 @@ export class AgentController {
 		this.drainingQueue = true;
 		try {
 			while (this.queue.length > 0) {
-				const queued = this.queue.shift();
+				const queued = this.takeNextSubmit();
 				if (!queued) continue;
 				try {
 					queued.onStart?.();
@@ -611,6 +631,10 @@ export class AgentController {
 	/** Cancels any active turn and starts a fresh Backboard thread. */
 	newThread(): void {
 		this.cancel({ clearQueue: true });
+		// Background agents were spawned to serve the discarded conversation;
+		// letting them report into the new thread would reference context that
+		// no longer exists.
+		this.deps.backgroundSupervisor?.cancelAll();
 		this.deps.session.reset();
 	}
 

--- a/src/core/agent/AgentController.ts
+++ b/src/core/agent/AgentController.ts
@@ -1,7 +1,9 @@
 import type { Config } from "../../config/Config.ts";
+import { formatModel } from "../../config/defaults.ts";
 import { qSessionDir } from "../../config/paths.ts";
 import { createRuntimeThinkingResolver } from "../../config/thinkingRuntime.ts";
 import { toPromptProfileId } from "../../prompts/profiles/ids.ts";
+import { buildExpertModePrompt } from "../../prompts/system/expertMode.tsx";
 import { getSystemPrompt } from "../../prompts/system/index.tsx";
 import { TODO_NOT_CALLED_REMINDER } from "../../prompts/todoReminders.ts";
 import type { AgentClient } from "../../providers/AgentClient.ts";
@@ -437,6 +439,13 @@ export class AgentController {
 					computerUseEnabled: config.isComputerUseEnabled,
 					browserUseEnabled: config.isBrowserUseEnabled,
 					skillDiscoveryEnabled: config.isSkillDiscoveryEnabled,
+					...(config.isExpertModeEnabled
+						? {
+								expertModePrompt: buildExpertModePrompt(
+									formatModel(config.executionModel),
+								),
+							}
+						: {}),
 					startupEnvironmentPrompt: this.deps.startupEnvironmentPrompt,
 					hookContext: joinHookContext(
 						this.deps.hookController?.baseContext,

--- a/src/core/agent/AgentControllerTypes.ts
+++ b/src/core/agent/AgentControllerTypes.ts
@@ -1,7 +1,22 @@
 import type { TurnStatus } from "../bus/events.ts";
 
+/**
+ * Drain order for queued submissions. `now` preempts (steering), `next` is
+ * ordinary user input, and `later` is for machine-generated work such as
+ * background sub-agent reports — filed last so system messages can never
+ * starve the human.
+ */
+export type SubmitPriority = "now" | "next" | "later";
+
+export const SUBMIT_PRIORITY_ORDER: Record<SubmitPriority, number> = {
+	now: 0,
+	next: 1,
+	later: 2,
+};
+
 export interface QueuedSubmit {
 	text: string;
+	priority: SubmitPriority;
 	emitUserMessage: boolean;
 	onStart?: () => void;
 	attachmentFilePaths?: string[];
@@ -15,6 +30,8 @@ export interface SubmitOptions {
 	onStart?: () => void;
 	attachmentFilePaths?: string[];
 	displayContent?: string;
+	/** Defaults to "next"; background reports pass "later". */
+	priority?: SubmitPriority;
 }
 
 export interface CancelOptions {

--- a/src/core/agent/BackgroundAgentSupervisor.ts
+++ b/src/core/agent/BackgroundAgentSupervisor.ts
@@ -5,6 +5,10 @@ import { truncate } from "../../utils/string.ts";
 import type { AgentDefinition } from "../agents/AgentDefinition.ts";
 import type { EventBus } from "../bus/EventBus.ts";
 import type { BackgroundRunSnapshot } from "../bus/events.ts";
+import {
+	formatSpawnTree,
+	type SpawnedAgent,
+} from "../tools/AgentToolOutput.ts";
 import type { SubAgentResult } from "./SubAgentTypes.ts";
 
 export const DEFAULT_BACKGROUND_MAX_CONCURRENT = 4;
@@ -13,23 +17,27 @@ const LABEL_LENGTH = 60;
 export interface BackgroundLaunchParams {
 	definition: AgentDefinition;
 	prompt: string;
-	/** Runs the sub-agent against the supervisor's own signal. */
 	run: (signal: AbortSignal) => Promise<SubAgentResult>;
+}
+
+export interface BackgroundAdoptParams {
+	definition: AgentDefinition;
+	prompt: string;
+	continuation: Promise<SubAgentResult>;
+	/** Stops the run. An adopted run has no signal of the supervisor's own. */
+	cancel: () => void;
 }
 
 interface BackgroundRun {
 	snapshot: BackgroundRunSnapshot;
-	abort: AbortController;
+	stop: () => void;
+	/** Set by cancelAll, so the run does not announce a result nobody asked for. */
+	stopped?: boolean;
 }
 
 /**
- * Owns sub-agents that outlive the turn that spawned them.
- *
- * Each run gets an AbortController deliberately unlinked from the parent turn,
- * so cancelling the foreground does not kill background work; `cancelAll` is
- * the explicit way to stop them. Completion is delivered back through the
- * notifier as a low-priority submission, which is why the supervisor never
- * touches the AgentController directly.
+ * Owns sub-agents that outlive the turn that spawned them. Runs are unlinked
+ * from that turn's cancellation; `cancelAll` is the way to stop them.
  */
 export class BackgroundAgentSupervisor {
 	private readonly runs = new Map<string, BackgroundRun>();
@@ -55,26 +63,70 @@ export class BackgroundAgentSupervisor {
 	}
 
 	launch(params: BackgroundLaunchParams): BackgroundRunSnapshot {
-		const id = shortId("bg");
 		const abort = new AbortController();
-		const snapshot: BackgroundRunSnapshot = {
-			id,
-			agent: params.definition.name,
-			label: truncate(params.prompt.replace(/\s+/gu, " ").trim(), LABEL_LENGTH),
-			status: "running",
-			startedAt: Date.now(),
-			rounds: 0,
-		};
-		this.runs.set(id, { snapshot, abort });
+		const { id, snapshot } = this.register(params, false);
+		this.runs.set(id, { snapshot, stop: () => abort.abort() });
 		this.bus.emit({ type: "agent:background_started", run: snapshot });
 
 		void this.drive(id, params, abort.signal);
 		return snapshot;
 	}
 
+	/** Takes over an in-flight run whose budget expired, without interrupting it. */
+	adopt(params: BackgroundAdoptParams): BackgroundRunSnapshot {
+		const { id, snapshot } = this.register(params, true);
+		// An adopted run started under the turn's signal and has since been
+		// detached from it, so stopping it means calling back into the runner.
+		this.runs.set(id, { snapshot, stop: params.cancel });
+		this.bus.emit({ type: "agent:background_started", run: snapshot });
+
+		void this.driveAdopted(id, params.continuation);
+		return snapshot;
+	}
+
+	private register(
+		params: { definition: AgentDefinition; prompt: string },
+		adopted: boolean,
+	): { id: string; snapshot: BackgroundRunSnapshot } {
+		const id = shortId("bg");
+		return {
+			id,
+			snapshot: {
+				id,
+				agent: params.definition.name,
+				label: truncate(
+					params.prompt.replace(/\s+/gu, " ").trim(),
+					LABEL_LENGTH,
+				),
+				status: "running",
+				startedAt: Date.now(),
+				rounds: 0,
+				...(adopted ? { adopted: true } : {}),
+			},
+		};
+	}
+
+	private async driveAdopted(
+		id: string,
+		continuation: Promise<SubAgentResult>,
+	): Promise<void> {
+		let result: SubAgentResult | undefined;
+		let failure: string | undefined;
+		try {
+			// Hold a permit for the rest of its life so an adopted run still
+			// counts against the background cap, even though it started earlier.
+			result = await this.slots.run(() => continuation);
+		} catch (err) {
+			failure = errorMessage(err);
+		}
+		this.finish(id, result, failure, false);
+	}
+
 	cancelAll(): void {
 		for (const run of this.runs.values()) {
-			if (run.snapshot.status === "running") run.abort.abort();
+			if (run.snapshot.status !== "running") continue;
+			run.stopped = true;
+			run.stop();
 		}
 	}
 
@@ -91,11 +143,21 @@ export class BackgroundAgentSupervisor {
 			failure = errorMessage(err);
 		}
 
+		this.finish(id, result, failure, signal.aborted);
+	}
+
+	private finish(
+		id: string,
+		result: SubAgentResult | undefined,
+		failure: string | undefined,
+		cancelled: boolean,
+	): void {
 		const run = this.runs.get(id);
 		if (!run) return;
+		const wasCancelled = cancelled || run.stopped === true;
 		run.snapshot = {
 			...run.snapshot,
-			status: signal.aborted
+			status: wasCancelled
 				? "cancelled"
 				: (result?.status ?? (failure ? "failed" : "completed")),
 			rounds: result?.toolRounds ?? run.snapshot.rounds,
@@ -108,28 +170,32 @@ export class BackgroundAgentSupervisor {
 
 		// A cancelled run was stopped deliberately; re-entering the loop to
 		// announce it would talk over whatever the user cancelled it for.
-		if (signal.aborted) return;
+		if (wasCancelled) return;
 		this.notifier?.(
-			backgroundReportMessage(run.snapshot, result?.report ?? failure ?? ""),
+			backgroundReportMessage(
+				run.snapshot,
+				result?.report ?? failure ?? "",
+				result?.children ?? [],
+			),
 		);
 	}
 }
 
-/**
- * The message injected back into the parent loop. It carries elapsed time
- * explicitly because the workspace may have moved on while the agent ran —
- * the parent must not assume its own earlier reads are still current.
- */
+/** Carries elapsed time, since the workspace may have moved on while it ran. */
 export function backgroundReportMessage(
 	run: BackgroundRunSnapshot,
 	report: string,
+	children: readonly SpawnedAgent[] = [],
 ): string {
+	const tree = children.length
+		? `\n\nSub-agents it spawned:\n${formatSpawnTree(children)}`
+		: "";
 	const elapsedS = Math.max(
 		1,
 		Math.round(((run.finishedAt ?? Date.now()) - run.startedAt) / 1000),
 	);
 	return `<agent-report agent="${run.agent}" status="${run.status}" rounds="${run.rounds}" elapsed="${elapsedS}s">
-${report.trim()}
+${report.trim()}${tree}
 </agent-report>
 
 The background agent "${run.agent}" you launched has finished; the report above is its output. It ran for ${elapsedS}s, so files you read before launching it may have changed — re-read anything you are about to act on. Continue the work this report was for, or tell the user what it found.`;

--- a/src/core/agent/BackgroundAgentSupervisor.ts
+++ b/src/core/agent/BackgroundAgentSupervisor.ts
@@ -168,12 +168,12 @@ export class BackgroundAgentSupervisor {
 			run: run.snapshot,
 		});
 
-		// A cancelled run was stopped deliberately; re-entering the loop to
-		// announce it would talk over whatever the user cancelled it for.
+		const snapshot = run.snapshot;
+		this.runs.delete(id);
 		if (wasCancelled) return;
 		this.notifier?.(
 			backgroundReportMessage(
-				run.snapshot,
+				snapshot,
 				result?.report ?? failure ?? "",
 				result?.children ?? [],
 			),

--- a/src/core/agent/BackgroundAgentSupervisor.ts
+++ b/src/core/agent/BackgroundAgentSupervisor.ts
@@ -1,0 +1,136 @@
+import { errorMessage } from "../../utils/errors.ts";
+import { shortId } from "../../utils/id.ts";
+import { Semaphore } from "../../utils/semaphore.ts";
+import { truncate } from "../../utils/string.ts";
+import type { AgentDefinition } from "../agents/AgentDefinition.ts";
+import type { EventBus } from "../bus/EventBus.ts";
+import type { BackgroundRunSnapshot } from "../bus/events.ts";
+import type { SubAgentResult } from "./SubAgentTypes.ts";
+
+export const DEFAULT_BACKGROUND_MAX_CONCURRENT = 4;
+const LABEL_LENGTH = 60;
+
+export interface BackgroundLaunchParams {
+	definition: AgentDefinition;
+	prompt: string;
+	/** Runs the sub-agent against the supervisor's own signal. */
+	run: (signal: AbortSignal) => Promise<SubAgentResult>;
+}
+
+interface BackgroundRun {
+	snapshot: BackgroundRunSnapshot;
+	abort: AbortController;
+}
+
+/**
+ * Owns sub-agents that outlive the turn that spawned them.
+ *
+ * Each run gets an AbortController deliberately unlinked from the parent turn,
+ * so cancelling the foreground does not kill background work; `cancelAll` is
+ * the explicit way to stop them. Completion is delivered back through the
+ * notifier as a low-priority submission, which is why the supervisor never
+ * touches the AgentController directly.
+ */
+export class BackgroundAgentSupervisor {
+	private readonly runs = new Map<string, BackgroundRun>();
+	private readonly slots: Semaphore;
+	private notifier: ((report: string) => void) | undefined;
+
+	constructor(
+		private readonly bus: EventBus,
+		maxConcurrent: number = DEFAULT_BACKGROUND_MAX_CONCURRENT,
+	) {
+		this.slots = new Semaphore(maxConcurrent);
+	}
+
+	/** Wired after construction: the controller needs the tools that need this. */
+	setNotifier(notifier: (report: string) => void): void {
+		this.notifier = notifier;
+	}
+
+	get active(): BackgroundRunSnapshot[] {
+		return [...this.runs.values()]
+			.map((run) => run.snapshot)
+			.filter((snapshot) => snapshot.status === "running");
+	}
+
+	launch(params: BackgroundLaunchParams): BackgroundRunSnapshot {
+		const id = shortId("bg");
+		const abort = new AbortController();
+		const snapshot: BackgroundRunSnapshot = {
+			id,
+			agent: params.definition.name,
+			label: truncate(params.prompt.replace(/\s+/gu, " ").trim(), LABEL_LENGTH),
+			status: "running",
+			startedAt: Date.now(),
+			rounds: 0,
+		};
+		this.runs.set(id, { snapshot, abort });
+		this.bus.emit({ type: "agent:background_started", run: snapshot });
+
+		void this.drive(id, params, abort.signal);
+		return snapshot;
+	}
+
+	cancelAll(): void {
+		for (const run of this.runs.values()) {
+			if (run.snapshot.status === "running") run.abort.abort();
+		}
+	}
+
+	private async drive(
+		id: string,
+		params: BackgroundLaunchParams,
+		signal: AbortSignal,
+	): Promise<void> {
+		let result: SubAgentResult | undefined;
+		let failure: string | undefined;
+		try {
+			result = await this.slots.run(() => params.run(signal));
+		} catch (err) {
+			failure = errorMessage(err);
+		}
+
+		const run = this.runs.get(id);
+		if (!run) return;
+		run.snapshot = {
+			...run.snapshot,
+			status: signal.aborted
+				? "cancelled"
+				: (result?.status ?? (failure ? "failed" : "completed")),
+			rounds: result?.toolRounds ?? run.snapshot.rounds,
+			finishedAt: Date.now(),
+		};
+		this.bus.emit({
+			type: "agent:background_finished",
+			run: run.snapshot,
+		});
+
+		// A cancelled run was stopped deliberately; re-entering the loop to
+		// announce it would talk over whatever the user cancelled it for.
+		if (signal.aborted) return;
+		this.notifier?.(
+			backgroundReportMessage(run.snapshot, result?.report ?? failure ?? ""),
+		);
+	}
+}
+
+/**
+ * The message injected back into the parent loop. It carries elapsed time
+ * explicitly because the workspace may have moved on while the agent ran —
+ * the parent must not assume its own earlier reads are still current.
+ */
+export function backgroundReportMessage(
+	run: BackgroundRunSnapshot,
+	report: string,
+): string {
+	const elapsedS = Math.max(
+		1,
+		Math.round(((run.finishedAt ?? Date.now()) - run.startedAt) / 1000),
+	);
+	return `<agent-report agent="${run.agent}" status="${run.status}" rounds="${run.rounds}" elapsed="${elapsedS}s">
+${report.trim()}
+</agent-report>
+
+The background agent "${run.agent}" you launched has finished; the report above is its output. It ran for ${elapsedS}s, so files you read before launching it may have changed — re-read anything you are about to act on. Continue the work this report was for, or tell the user what it found.`;
+}

--- a/src/core/agent/BackgroundAgentSupervisor.ts
+++ b/src/core/agent/BackgroundAgentSupervisor.ts
@@ -113,9 +113,7 @@ export class BackgroundAgentSupervisor {
 		let result: SubAgentResult | undefined;
 		let failure: string | undefined;
 		try {
-			// Hold a permit for the rest of its life so an adopted run still
-			// counts against the background cap, even though it started earlier.
-			result = await this.slots.run(() => continuation);
+			result = await continuation;
 		} catch (err) {
 			failure = errorMessage(err);
 		}
@@ -138,7 +136,7 @@ export class BackgroundAgentSupervisor {
 		let result: SubAgentResult | undefined;
 		let failure: string | undefined;
 		try {
-			result = await this.slots.run(() => params.run(signal));
+			result = await this.slots.run(() => params.run(signal), signal);
 		} catch (err) {
 			failure = errorMessage(err);
 		}

--- a/src/core/agent/BackgroundAgentSupervisor.ts
+++ b/src/core/agent/BackgroundAgentSupervisor.ts
@@ -56,6 +56,15 @@ export class BackgroundAgentSupervisor {
 		this.notifier = notifier;
 	}
 
+	/**
+	 * Drops the notifier for good. `finish` removes a run before reporting, so
+	 * `cancelAll` cannot reach one that already completed: shutdown has to
+	 * close this door too, or a late report starts a turn mid-teardown.
+	 */
+	disableNotifier(): void {
+		this.notifier = undefined;
+	}
+
 	get active(): BackgroundRunSnapshot[] {
 		return [...this.runs.values()]
 			.map((run) => run.snapshot)

--- a/src/core/agent/RunBudget.ts
+++ b/src/core/agent/RunBudget.ts
@@ -6,8 +6,12 @@ export class RunTimeoutError extends Error {
 }
 
 export interface RunBudgetOptions {
-	/** False keeps the run alive past the deadline; await `expiry` instead. */
-	abortOnExpiry?: boolean;
+	/**
+	 * False keeps the run alive past the deadline; await `expiry` instead. A
+	 * function is consulted when the deadline fires, for a run whose waiter
+	 * may have gone away (moved to the background) since it started.
+	 */
+	abortOnExpiry?: boolean | (() => boolean);
 }
 
 /**
@@ -19,7 +23,7 @@ export class RunBudget {
 	private readonly timeout: ReturnType<typeof setTimeout> | null = null;
 	private readonly abortFromParent: () => void;
 	private readonly deadlineMs: number;
-	private readonly abortOnExpiry: boolean;
+	private readonly abortOnExpiry: () => boolean;
 	private signalExpiry!: () => void;
 	private expired = false;
 	private detached = false;
@@ -32,7 +36,9 @@ export class RunBudget {
 		readonly timeoutMs?: number,
 		options: RunBudgetOptions = {},
 	) {
-		this.abortOnExpiry = options.abortOnExpiry ?? true;
+		const abortOnExpiry = options.abortOnExpiry ?? true;
+		this.abortOnExpiry =
+			typeof abortOnExpiry === "function" ? abortOnExpiry : () => abortOnExpiry;
 		this.expiry = new Promise<void>((resolve) => {
 			this.signalExpiry = resolve;
 		});
@@ -54,7 +60,7 @@ export class RunBudget {
 		if (timeoutMs !== undefined) {
 			this.timeout = setTimeout(() => {
 				this.expired = true;
-				if (this.abortOnExpiry) {
+				if (this.abortOnExpiry()) {
 					this.controller.abort(new RunTimeoutError(timeoutMs));
 				}
 				this.signalExpiry();

--- a/src/core/agent/RunBudget.ts
+++ b/src/core/agent/RunBudget.ts
@@ -1,0 +1,86 @@
+export class RunTimeoutError extends Error {
+	constructor(timeoutMs: number) {
+		super(`Run timed out after ${Math.ceil(timeoutMs / 1000)} seconds`);
+		this.name = "RunTimeoutError";
+	}
+}
+
+/**
+ * A wall-clock budget layered over a parent AbortSignal. Expiry is
+ * distinguishable from a parent cancel so callers can degrade gracefully —
+ * summarizing partial progress — instead of discarding the run's work.
+ */
+export class RunBudget {
+	private readonly controller = new AbortController();
+	private readonly timeout: ReturnType<typeof setTimeout> | null = null;
+	private readonly abortFromParent: () => void;
+	private readonly deadlineMs: number;
+	private expired = false;
+
+	private constructor(
+		private readonly parentSignal: AbortSignal,
+		readonly timeoutMs?: number,
+	) {
+		this.deadlineMs =
+			timeoutMs === undefined
+				? Number.POSITIVE_INFINITY
+				: Date.now() + timeoutMs;
+		this.abortFromParent = (): void => {
+			this.controller.abort(parentSignal.reason);
+		};
+		if (parentSignal.aborted) {
+			this.abortFromParent();
+		} else {
+			parentSignal.addEventListener("abort", this.abortFromParent, {
+				once: true,
+			});
+		}
+
+		if (timeoutMs !== undefined) {
+			this.timeout = setTimeout(() => {
+				this.expired = true;
+				this.controller.abort(new RunTimeoutError(timeoutMs));
+			}, timeoutMs);
+		}
+	}
+
+	static start(parentSignal: AbortSignal, timeoutMs?: number): RunBudget {
+		return new RunBudget(parentSignal, timeoutMs);
+	}
+
+	get signal(): AbortSignal {
+		return this.controller.signal;
+	}
+
+	/** True only for budget expiry; a parent cancel reports false. */
+	get timedOut(): boolean {
+		return this.expired && !this.parentSignal.aborted;
+	}
+
+	get remainingMs(): number | undefined {
+		if (this.timeoutMs === undefined) return undefined;
+		if (this.expired) return 1;
+		return Math.max(1, this.deadlineMs - Date.now());
+	}
+
+	throwIfExpired(): void {
+		if (this.expired) throw new RunTimeoutError(this.timeoutMs ?? 0);
+		if (this.signal.aborted && !this.parentSignal.aborted) {
+			throw this.signal.reason instanceof Error
+				? this.signal.reason
+				: new RunTimeoutError(this.timeoutMs ?? 0);
+		}
+	}
+
+	isTimeoutError(error: Error): boolean {
+		return (
+			error instanceof RunTimeoutError ||
+			(!this.parentSignal.aborted && this.signal.aborted && this.expired)
+		);
+	}
+
+	dispose(): void {
+		if (this.timeout) clearTimeout(this.timeout);
+		this.parentSignal.removeEventListener("abort", this.abortFromParent);
+	}
+}

--- a/src/core/agent/RunBudget.ts
+++ b/src/core/agent/RunBudget.ts
@@ -5,22 +5,37 @@ export class RunTimeoutError extends Error {
 	}
 }
 
+export interface RunBudgetOptions {
+	/** False keeps the run alive past the deadline; await `expiry` instead. */
+	abortOnExpiry?: boolean;
+}
+
 /**
- * A wall-clock budget layered over a parent AbortSignal. Expiry is
- * distinguishable from a parent cancel so callers can degrade gracefully —
- * summarizing partial progress — instead of discarding the run's work.
+ * A wall-clock budget over a parent AbortSignal. Expiry is distinguishable from
+ * a parent cancel, so callers can degrade instead of discarding the run's work.
  */
 export class RunBudget {
 	private readonly controller = new AbortController();
 	private readonly timeout: ReturnType<typeof setTimeout> | null = null;
 	private readonly abortFromParent: () => void;
 	private readonly deadlineMs: number;
+	private readonly abortOnExpiry: boolean;
+	private signalExpiry!: () => void;
 	private expired = false;
+	private detached = false;
+
+	/** Resolves once the deadline passes. Never rejects; never resolves without one. */
+	readonly expiry: Promise<void>;
 
 	private constructor(
 		private readonly parentSignal: AbortSignal,
 		readonly timeoutMs?: number,
+		options: RunBudgetOptions = {},
 	) {
+		this.abortOnExpiry = options.abortOnExpiry ?? true;
+		this.expiry = new Promise<void>((resolve) => {
+			this.signalExpiry = resolve;
+		});
 		this.deadlineMs =
 			timeoutMs === undefined
 				? Number.POSITIVE_INFINITY
@@ -39,13 +54,20 @@ export class RunBudget {
 		if (timeoutMs !== undefined) {
 			this.timeout = setTimeout(() => {
 				this.expired = true;
-				this.controller.abort(new RunTimeoutError(timeoutMs));
+				if (this.abortOnExpiry) {
+					this.controller.abort(new RunTimeoutError(timeoutMs));
+				}
+				this.signalExpiry();
 			}, timeoutMs);
 		}
 	}
 
-	static start(parentSignal: AbortSignal, timeoutMs?: number): RunBudget {
-		return new RunBudget(parentSignal, timeoutMs);
+	static start(
+		parentSignal: AbortSignal,
+		timeoutMs?: number,
+		options: RunBudgetOptions = {},
+	): RunBudget {
+		return new RunBudget(parentSignal, timeoutMs, options);
 	}
 
 	get signal(): AbortSignal {
@@ -55,6 +77,24 @@ export class RunBudget {
 	/** True only for budget expiry; a parent cancel reports false. */
 	get timedOut(): boolean {
 		return this.expired && !this.parentSignal.aborted;
+	}
+
+	cancel(reason?: unknown): void {
+		this.controller.abort(reason);
+	}
+
+	/** Enforces the deadline late, for a caller that declined the handoff. */
+	abortForTimeout(): void {
+		this.expired = true;
+		this.controller.abort(new RunTimeoutError(this.timeoutMs ?? 0));
+		this.signalExpiry();
+	}
+
+	/** Stops forwarding the parent's cancel, for a run that outlives its turn. */
+	detachFromParent(): void {
+		if (this.detached) return;
+		this.detached = true;
+		this.parentSignal.removeEventListener("abort", this.abortFromParent);
 	}
 
 	get remainingMs(): number | undefined {
@@ -81,6 +121,6 @@ export class RunBudget {
 
 	dispose(): void {
 		if (this.timeout) clearTimeout(this.timeout);
-		this.parentSignal.removeEventListener("abort", this.abortFromParent);
+		this.detachFromParent();
 	}
 }

--- a/src/core/agent/SubAgentConstants.ts
+++ b/src/core/agent/SubAgentConstants.ts
@@ -1,1 +1,18 @@
 export const MAX_SUBAGENT_TOOL_ROUNDS = 20;
+
+/** Ceiling on the post-timeout summary turn, so expiry stays bounded. */
+export const SUBAGENT_TIMEOUT_SUMMARY_MS = 15_000;
+
+export const TIMED_OUT_WITHOUT_REPORT =
+	"(the sub-agent ran out of time before producing a report)";
+
+export function timeoutSummaryPrompt(definition: { name: string }): string {
+	return `Your time budget expired before you finished this task.
+
+Report now, using only what you already established:
+- What you found, with file paths.
+- What you did not get to.
+- Any files you modified.
+
+Do not start new work. This is your final message as the "${definition.name}" sub-agent.`;
+}

--- a/src/core/agent/SubAgentConstants.ts
+++ b/src/core/agent/SubAgentConstants.ts
@@ -1,5 +1,16 @@
 export const MAX_SUBAGENT_TOOL_ROUNDS = 20;
 
+const REPORT_CONTRACT = `You cannot ask the user anything. Work with the tools you have, then stop.
+Finish with a single concise final message that is your report: the parent receives that message and nothing else. Do not narrate your process.`;
+
+/**
+ * A custom agent's markdown body defines its role; the contract the runner
+ * depends on is appended so it cannot be dropped by overriding the prompt.
+ */
+export function subAgentSystemPrompt(body: string): string {
+	return `${body.trim()}\n\n${REPORT_CONTRACT}`;
+}
+
 /** Ceiling on the post-timeout summary turn, so expiry stays bounded. */
 export const SUBAGENT_TIMEOUT_SUMMARY_MS = 15_000;
 

--- a/src/core/agent/SubAgentConstants.ts
+++ b/src/core/agent/SubAgentConstants.ts
@@ -3,6 +3,9 @@ export const MAX_SUBAGENT_TOOL_ROUNDS = 20;
 /** Ceiling on the post-timeout summary turn, so expiry stays bounded. */
 export const SUBAGENT_TIMEOUT_SUMMARY_MS = 15_000;
 
+export const HANDED_OFF_REPORT =
+	"Budget expired while the sub-agent was still working, so it moved to the background rather than losing its progress.";
+
 export const TIMED_OUT_WITHOUT_REPORT =
 	"(the sub-agent ran out of time before producing a report)";
 

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -1,3 +1,5 @@
+import type { ModelRef, ThinkingConfig } from "../../config/defaults.ts";
+import type { RuntimeThinkingResolver } from "../../config/thinkingRuntime.ts";
 import { shortId } from "../../utils/id.ts";
 import { EventBus } from "../bus/EventBus.ts";
 import { emptyRuleSet } from "../permissions/PermissionRules.ts";
@@ -6,7 +8,13 @@ import { Session } from "../session/Session.ts";
 import type { ToolContext } from "../tools/ToolContext.ts";
 import { ToolRegistry } from "../tools/ToolRegistry.ts";
 import { AgentLoopFactory } from "./AgentLoopFactory.ts";
-import { MAX_SUBAGENT_TOOL_ROUNDS } from "./SubAgentConstants.ts";
+import { RunBudget } from "./RunBudget.ts";
+import {
+	MAX_SUBAGENT_TOOL_ROUNDS,
+	SUBAGENT_TIMEOUT_SUMMARY_MS,
+	TIMED_OUT_WITHOUT_REPORT,
+	timeoutSummaryPrompt,
+} from "./SubAgentConstants.ts";
 import type {
 	SubAgentResult,
 	SubAgentRunnerDeps,
@@ -17,6 +25,7 @@ export type {
 	SubAgentResult,
 	SubAgentRunnerDeps,
 	SubAgentRunParams,
+	SubAgentStatus,
 	SubAgentToolFactory,
 } from "./SubAgentTypes.ts";
 
@@ -55,6 +64,7 @@ export class SubAgentRunner {
 
 		const tools = this.deps.toolFactory({
 			depth: params.depth,
+			definition: params.definition,
 		});
 		const registry = new ToolRegistry(tools);
 		const toolSchemas = registry.toJSONSchemas();
@@ -68,7 +78,7 @@ export class SubAgentRunner {
 			isToolEnabled: this.deps.isToolEnabled,
 		});
 
-		const model = this.deps.getModel();
+		const model = params.definition.model ?? this.deps.getModel();
 		const thinkingResolver = this.deps.getThinkingResolver
 			? await this.deps.getThinkingResolver()
 			: undefined;
@@ -88,11 +98,16 @@ export class SubAgentRunner {
 			? parentRecorder?.scopedToTurn(params.parentTurnId)
 			: undefined;
 
+		const budget = RunBudget.start(
+			params.parentSignal,
+			params.definition.timeoutMs,
+		);
+
 		const ctx: ToolContext = {
 			sessionId: session.sessionId,
 			cwd: params.parentCwd,
 			bus,
-			signal: params.parentSignal,
+			signal: budget.signal,
 			// A sub-agent can never prompt the human, so AskUser is unavailable.
 			askUser: async () => {
 				throw new Error("A sub-agent cannot ask the user a question.");
@@ -115,18 +130,39 @@ export class SubAgentRunner {
 			session,
 			bus,
 			tools: toolSchemas,
-			systemPrompt: this.deps.systemPrompt,
+			systemPrompt: params.definition.systemPrompt,
 			model,
 			memory: this.deps.memory,
 			memoryProfile: this.deps.memoryProfile,
 			thinking,
 			thinkingResolver,
 			requestKind: "subagent",
-			maxToolRounds: MAX_SUBAGENT_TOOL_ROUNDS,
+			maxToolRounds: params.definition.maxRounds ?? MAX_SUBAGENT_TOOL_ROUNDS,
 		});
 
 		try {
 			const status = await loop.run(params.prompt.trim(), ctx);
+
+			// A timeout surfaces as a cancelled turn. Rather than discard the work,
+			// spend one short bounded turn asking for what it established so far.
+			if (status === "cancelled" && budget.timedOut) {
+				await this.summarizeAfterTimeout({
+					loopFactory,
+					session,
+					bus,
+					ctx,
+					params,
+					model,
+					thinking,
+					thinkingResolver,
+				});
+				return {
+					report: reports.at(-1) ?? TIMED_OUT_WITHOUT_REPORT,
+					status: "timed_out",
+					usage: session.usage,
+					toolRounds: loop.toolRounds,
+				};
+			}
 
 			return {
 				report: reports.at(-1) ?? "(the sub-agent produced no output)",
@@ -135,9 +171,60 @@ export class SubAgentRunner {
 				toolRounds: loop.toolRounds,
 			};
 		} finally {
+			budget.dispose();
 			detachParentProgress();
 			detachSessionProjection();
 			await childLog?.flush();
+		}
+	}
+
+	/**
+	 * Runs one tool-less turn on the timed-out sub-agent's own session, so the
+	 * report reflects its actual findings. Best-effort: a failure here leaves the
+	 * last streamed message as the report rather than losing the run.
+	 */
+	private async summarizeAfterTimeout(input: {
+		loopFactory: AgentLoopFactory;
+		session: Session;
+		bus: EventBus;
+		ctx: ToolContext;
+		params: SubAgentRunParams;
+		model: ModelRef;
+		thinking: ThinkingConfig | null | undefined;
+		thinkingResolver: RuntimeThinkingResolver | undefined;
+	}): Promise<void> {
+		const signal = AbortSignal.any([
+			input.params.parentSignal,
+			AbortSignal.timeout(SUBAGENT_TIMEOUT_SUMMARY_MS),
+		]);
+		if (signal.aborted) return;
+
+		const registry = new ToolRegistry([]);
+		const summaryLoop = input.loopFactory.createLoop({
+			scheduler: input.loopFactory.createScheduler({
+				registry,
+				bus: input.bus,
+			}),
+			session: input.session,
+			bus: input.bus,
+			tools: [],
+			systemPrompt: input.params.definition.systemPrompt,
+			model: input.model,
+			memory: this.deps.memory,
+			memoryProfile: this.deps.memoryProfile,
+			thinking: input.thinking,
+			thinkingResolver: input.thinkingResolver,
+			requestKind: "subagent",
+			maxToolRounds: 0,
+		});
+
+		try {
+			await summaryLoop.run(timeoutSummaryPrompt(input.params.definition), {
+				...input.ctx,
+				signal,
+			});
+		} catch {
+			// Keep whatever streamed before the budget expired.
 		}
 	}
 

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -5,11 +5,13 @@ import { EventBus } from "../bus/EventBus.ts";
 import { emptyRuleSet } from "../permissions/PermissionRules.ts";
 import { ClientEventLog } from "../session/ClientEventLog.ts";
 import { Session } from "../session/Session.ts";
+import type { SpawnedAgent } from "../tools/AgentToolOutput.ts";
 import type { ToolContext } from "../tools/ToolContext.ts";
 import { ToolRegistry } from "../tools/ToolRegistry.ts";
 import { AgentLoopFactory } from "./AgentLoopFactory.ts";
 import { RunBudget } from "./RunBudget.ts";
 import {
+	HANDED_OFF_REPORT,
 	MAX_SUBAGENT_TOOL_ROUNDS,
 	SUBAGENT_TIMEOUT_SUMMARY_MS,
 	TIMED_OUT_WITHOUT_REPORT,
@@ -22,6 +24,7 @@ import type {
 } from "./SubAgentTypes.ts";
 
 export type {
+	DeadlineHandoff,
 	SubAgentResult,
 	SubAgentRunnerDeps,
 	SubAgentRunParams,
@@ -55,6 +58,20 @@ export class SubAgentRunner {
 			});
 		}
 		const detachParentProgress = this.attachParentProgressRelay(params, bus);
+
+		// Every Agent result on this private bus is a sub-agent this run spawned.
+		const spawned: SpawnedAgent[] = [];
+		bus.on("tool:result", (event) => {
+			const output = event.agentOutput;
+			if (!output) return;
+			spawned.push({
+				agent: output.agent ?? "agent",
+				status: output.status,
+				rounds: output.rounds,
+				...(output.runId ? { runId: output.runId } : {}),
+				...(output.children?.length ? { children: output.children } : {}),
+			});
+		});
 
 		const reports: string[] = [];
 		bus.on("assistant:message", (event) => {
@@ -98,9 +115,14 @@ export class SubAgentRunner {
 			? parentRecorder?.scopedToTurn(params.parentTurnId)
 			: undefined;
 
+		// A budget bounds how long someone waits. With a handoff, or once the
+		// chain is already backgrounded, nobody is: expiry must not abort.
+		const canHandOff = params.onDeadline !== undefined;
+		const noWaiter = params.parentInBackground === true;
 		const budget = RunBudget.start(
 			params.parentSignal,
 			params.definition.timeoutMs,
+			{ abortOnExpiry: !canHandOff && !noWaiter },
 		);
 
 		const ctx: ToolContext = {
@@ -114,6 +136,7 @@ export class SubAgentRunner {
 			},
 			getTodos: () => session.todos,
 			agentDepth: params.depth,
+			inBackgroundChain: params.chainInBackground === true,
 			trace: params.trace?.context,
 			lsp: this.deps.lsp,
 			checkpoints,
@@ -140,49 +163,83 @@ export class SubAgentRunner {
 			maxToolRounds: params.definition.maxRounds ?? MAX_SUBAGENT_TOOL_ROUNDS,
 		});
 
-		try {
-			const status = await loop.run(params.prompt.trim(), ctx);
+		let handedOff = false;
+		const settle = (async (): Promise<SubAgentResult> => {
+			try {
+				const status = await loop.run(params.prompt.trim(), ctx);
 
-			// A timeout surfaces as a cancelled turn. Rather than discard the work,
-			// spend one short bounded turn asking for what it established so far.
-			if (status === "cancelled" && budget.timedOut) {
-				await this.summarizeAfterTimeout({
-					loopFactory,
-					session,
-					bus,
-					ctx,
-					params,
-					model,
-					thinking,
-					thinkingResolver,
-				});
+				// The deadline aborted the turn; salvage what it established.
+				if (status === "cancelled" && budget.timedOut && !handedOff) {
+					await this.summarizeAfterTimeout({
+						loopFactory,
+						session,
+						bus,
+						ctx,
+						params,
+						model,
+						thinking,
+						thinkingResolver,
+					});
+					return {
+						report: reports.at(-1) ?? TIMED_OUT_WITHOUT_REPORT,
+						status: "timed_out",
+						usage: session.usage,
+						toolRounds: loop.toolRounds,
+						...(spawned.length ? { children: [...spawned] } : {}),
+					};
+				}
+
 				return {
-					report: reports.at(-1) ?? TIMED_OUT_WITHOUT_REPORT,
-					status: "timed_out",
+					report: reports.at(-1) ?? "(the sub-agent produced no output)",
+					status,
 					usage: session.usage,
 					toolRounds: loop.toolRounds,
+					...(spawned.length ? { children: [...spawned] } : {}),
 				};
+			} finally {
+				budget.dispose();
+				detachParentProgress();
+				detachSessionProjection();
+				await childLog?.flush();
 			}
+		})();
 
-			return {
-				report: reports.at(-1) ?? "(the sub-agent produced no output)",
-				status,
-				usage: session.usage,
-				toolRounds: loop.toolRounds,
-			};
-		} finally {
-			budget.dispose();
-			detachParentProgress();
-			detachSessionProjection();
-			await childLog?.flush();
+		if (!canHandOff) return settle;
+
+		// Whichever comes first: the run finishing, or its budget running out.
+		const outcome = await Promise.race([
+			settle.then((result) => ({ kind: "settled" as const, result })),
+			budget.expiry.then(() => ({ kind: "expired" as const })),
+		]);
+		if (outcome.kind === "settled") return outcome.result;
+
+		const handle = params.onDeadline?.({
+			continuation: settle,
+			cancel: () => budget.cancel(),
+		});
+		if (!handle) {
+			// Nowhere to hand it off to, so enforce the budget after all.
+			budget.abortForTimeout();
+			return settle;
 		}
+
+		// The turn no longer owns this run, so its cancellation must not reach
+		// it, and its progress must stop touching a tool row that is now closed.
+		handedOff = true;
+		budget.detachFromParent();
+		detachParentProgress();
+		return {
+			report: HANDED_OFF_REPORT,
+			status: "backgrounded",
+			usage: session.usage,
+			toolRounds: loop.toolRounds,
+			runId: handle.runId,
+			...(params.trace ? { logPath: params.trace.clientLogPath } : {}),
+			...(spawned.length ? { children: [...spawned] } : {}),
+		};
 	}
 
-	/**
-	 * Runs one tool-less turn on the timed-out sub-agent's own session, so the
-	 * report reflects its actual findings. Best-effort: a failure here leaves the
-	 * last streamed message as the report rather than losing the run.
-	 */
+	/** One tool-less turn on the run's own session. Best-effort. */
 	private async summarizeAfterTimeout(input: {
 		loopFactory: AgentLoopFactory;
 		session: Session;

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -7,8 +7,12 @@ import { emptyRuleSet } from "../permissions/PermissionRules.ts";
 import { ClientEventLog } from "../session/ClientEventLog.ts";
 import { Session } from "../session/Session.ts";
 import type { SpawnedAgent } from "../tools/AgentToolOutput.ts";
-import type { ToolContext } from "../tools/ToolContext.ts";
+import type {
+	BackgroundChainState,
+	ToolContext,
+} from "../tools/ToolContext.ts";
 import { ToolRegistry } from "../tools/ToolRegistry.ts";
+import type { AgentLoop } from "./AgentLoop.ts";
 import { AgentLoopFactory } from "./AgentLoopFactory.ts";
 import { RunBudget } from "./RunBudget.ts";
 import {
@@ -81,9 +85,12 @@ export class SubAgentRunner {
 			if (text) reports.push(text);
 		});
 
+		const model = params.definition.model ?? this.deps.getModel();
+
 		const tools = this.deps.toolFactory({
 			depth: params.depth,
 			definition: params.definition,
+			model,
 		});
 		const registry = new ToolRegistry(tools);
 		const toolSchemas = registry.toJSONSchemas();
@@ -94,16 +101,8 @@ export class SubAgentRunner {
 		const scheduler = loopFactory.createScheduler({
 			registry,
 			bus,
-			isToolEnabled: this.deps.isToolEnabled,
+			isToolEnabled: (name) => this.deps.isToolEnabled?.(name, model) ?? true,
 		});
-
-		const model = params.definition.model ?? this.deps.getModel();
-		const thinkingResolver = this.deps.getThinkingResolver
-			? await this.deps.getThinkingResolver()
-			: undefined;
-		const thinking = thinkingResolver
-			? undefined
-			: await this.deps.getThinking();
 
 		// The sub-agent's turns live on this private bus, so the shared
 		// CheckpointStore never sees their turn:end and would never finalize a
@@ -120,14 +119,38 @@ export class SubAgentRunner {
 		const checkpoints = revocable?.recorder;
 
 		// A budget bounds how long someone waits. With a handoff, or once the
-		// chain is already backgrounded, nobody is: expiry must not abort.
+		// chain above is backgrounded, nobody is: expiry must not abort. The
+		// chain is consulted when the deadline fires, since the parent may have
+		// been handed off while this run was underway. Started before the
+		// model-metadata preflight below, which is a network round-trip: a
+		// lookup that stalls must still reach the deadline, or a call with a
+		// timeout would sit in the foreground without ever timing out or
+		// handing off.
 		const canHandOff = params.onDeadline !== undefined;
-		const noWaiter = params.parentInBackground === true;
+		const parentChain = params.parentChain;
 		const budget = RunBudget.start(
 			params.parentSignal,
 			params.timeoutMs ?? params.definition.timeoutMs,
-			{ abortOnExpiry: !canHandOff && !noWaiter },
+			{
+				abortOnExpiry: () => !canHandOff && parentChain?.inBackground !== true,
+			},
 		);
+
+		// Read through every context copy the tool rounds make, so a handoff
+		// anywhere up the chain changes what descendants see from then on.
+		// Closes over locals, not `params`, so the chain link a descendant keeps
+		// does not pin this run's prompt and permissions.
+		let handedOff = false;
+		const launchedInBackground = params.chainInBackground === true;
+		const backgroundChain: BackgroundChainState = {
+			get inBackground() {
+				return (
+					launchedInBackground ||
+					handedOff ||
+					parentChain?.inBackground === true
+				);
+			},
+		};
 
 		const ctx: ToolContext = {
 			sessionId: session.sessionId,
@@ -140,7 +163,7 @@ export class SubAgentRunner {
 			},
 			getTodos: () => session.todos,
 			agentDepth: params.depth,
-			inBackgroundChain: params.chainInBackground === true,
+			backgroundChain,
 			trace: params.trace?.context,
 			lsp: this.deps.lsp,
 			checkpoints,
@@ -152,24 +175,43 @@ export class SubAgentRunner {
 				: { mode: "manual", rules: emptyRuleSet(), interactive: false },
 		};
 
-		const loop = loopFactory.createLoop({
-			scheduler,
-			session,
-			bus,
-			tools: toolSchemas,
-			systemPrompt: subAgentSystemPrompt(params.definition.systemPrompt),
-			model,
-			memory: this.deps.memory,
-			memoryProfile: this.deps.memoryProfile,
-			thinking,
-			thinkingResolver,
-			requestKind: "subagent",
-			maxToolRounds: params.definition.maxRounds ?? MAX_SUBAGENT_TOOL_ROUNDS,
-		});
+		// Built inside `settle` so the deadline race below is already armed
+		// while the preflight runs; nothing outside may assume it exists yet.
+		let loop: AgentLoop | undefined;
 
-		let handedOff = false;
 		const settle = (async (): Promise<SubAgentResult> => {
 			try {
+				const { thinking, thinkingResolver } = await this.preflight(
+					model,
+					budget.signal,
+				);
+				// Aborted before any turn ran: nothing to run and nothing a
+				// summary turn could salvage.
+				if (budget.signal.aborted) {
+					return {
+						report: budget.timedOut
+							? TIMED_OUT_WITHOUT_REPORT
+							: "(the sub-agent produced no output)",
+						status: budget.timedOut ? "timed_out" : "cancelled",
+						usage: session.usage,
+						toolRounds: 0,
+					};
+				}
+				loop = loopFactory.createLoop({
+					scheduler,
+					session,
+					bus,
+					tools: toolSchemas,
+					systemPrompt: subAgentSystemPrompt(params.definition.systemPrompt),
+					model,
+					memory: this.deps.memory,
+					memoryProfile: this.deps.memoryProfile,
+					thinking,
+					thinkingResolver,
+					requestKind: "subagent",
+					maxToolRounds:
+						params.definition.maxRounds ?? MAX_SUBAGENT_TOOL_ROUNDS,
+				});
 				const status = await loop.run(params.prompt.trim(), ctx);
 
 				// The deadline aborted the turn; salvage what it established.
@@ -229,19 +271,42 @@ export class SubAgentRunner {
 
 		// The turn no longer owns this run, so its cancellation must not reach
 		// it, and its progress must stop touching a tool row that is now closed.
+		// Also moves `backgroundChain` to the background, so budgets stop being
+		// enforced for anything the run spawns from here on.
 		handedOff = true;
 		budget.detachFromParent();
 		detachParentProgress();
-		revocable?.revoke();
+		await revocable?.revoke();
 		return {
 			report: HANDED_OFF_REPORT,
 			status: "backgrounded",
 			usage: session.usage,
-			toolRounds: loop.toolRounds,
+			toolRounds: loop?.toolRounds ?? 0,
 			runId: handle.runId,
 			...(params.trace ? { logPath: params.trace.clientLogPath } : {}),
 			...(spawned.length ? { children: [...spawned] } : {}),
 		};
+	}
+
+	/**
+	 * Resolves the model's thinking configuration. `signal` cancels the
+	 * metadata request: an enforced deadline must not be held open by it, and
+	 * the run it belongs to is about to be cancelled anyway.
+	 */
+	private async preflight(
+		model: ModelRef,
+		signal: AbortSignal,
+	): Promise<{
+		thinking: ThinkingConfig | null | undefined;
+		thinkingResolver: RuntimeThinkingResolver | undefined;
+	}> {
+		const thinkingResolver = this.deps.getThinkingResolver
+			? await this.deps.getThinkingResolver(model, signal)
+			: undefined;
+		const thinking = thinkingResolver
+			? undefined
+			: await this.deps.getThinking(model, signal);
+		return { thinking, thinkingResolver };
 	}
 
 	/** One tool-less turn on the run's own session. Best-effort. */

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -14,6 +14,7 @@ import {
 	HANDED_OFF_REPORT,
 	MAX_SUBAGENT_TOOL_ROUNDS,
 	SUBAGENT_TIMEOUT_SUMMARY_MS,
+	subAgentSystemPrompt,
 	TIMED_OUT_WITHOUT_REPORT,
 	timeoutSummaryPrompt,
 } from "./SubAgentConstants.ts";
@@ -153,7 +154,7 @@ export class SubAgentRunner {
 			session,
 			bus,
 			tools: toolSchemas,
-			systemPrompt: params.definition.systemPrompt,
+			systemPrompt: subAgentSystemPrompt(params.definition.systemPrompt),
 			model,
 			memory: this.deps.memory,
 			memoryProfile: this.deps.memoryProfile,

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -141,6 +141,7 @@ export class SubAgentRunner {
 		// Closes over locals, not `params`, so the chain link a descendant keeps
 		// does not pin this run's prompt and permissions.
 		let handedOff = false;
+		const escalationAbort = new AbortController();
 		const parentPermissions = params.parentPermissions;
 		const launchedInBackground = params.chainInBackground === true;
 		const backgroundChain: BackgroundChainState = {
@@ -178,10 +179,18 @@ export class SubAgentRunner {
 						interactive: false,
 						escalate: () => {
 							if (backgroundChain.inBackground) return null;
-							if (parentPermissions.interactive) {
-								return params.parentAskUser ?? null;
-							}
-							return parentPermissions.escalate?.() ?? null;
+							const upstream = parentPermissions.interactive
+								? params.parentAskUser
+								: parentPermissions.escalate?.();
+							if (!upstream) return null;
+							return (question, options, signal) =>
+								upstream(
+									question,
+									options,
+									signal
+										? AbortSignal.any([signal, escalationAbort.signal])
+										: escalationAbort.signal,
+								);
 						},
 						promptHost: parentPermissions.promptHost ?? parentPermissions,
 					}
@@ -287,6 +296,7 @@ export class SubAgentRunner {
 		// Also moves `backgroundChain` to the background, so budgets stop being
 		// enforced for anything the run spawns from here on.
 		handedOff = true;
+		escalationAbort.abort();
 		budget.detachFromParent();
 		detachParentProgress();
 		await revocable?.revoke();

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -2,6 +2,7 @@ import type { ModelRef, ThinkingConfig } from "../../config/defaults.ts";
 import type { RuntimeThinkingResolver } from "../../config/thinkingRuntime.ts";
 import { shortId } from "../../utils/id.ts";
 import { EventBus } from "../bus/EventBus.ts";
+import { revocableRecorder } from "../checkpoints/CheckpointStore.ts";
 import { emptyRuleSet } from "../permissions/PermissionRules.ts";
 import { ClientEventLog } from "../session/ClientEventLog.ts";
 import { Session } from "../session/Session.ts";
@@ -112,9 +113,11 @@ export class SubAgentRunner {
 		// turn to attribute to, capture is disabled rather than journaling
 		// entries no checkpoint could ever surface.
 		const parentRecorder = params.checkpoints ?? this.deps.checkpoints;
-		const checkpoints = params.parentTurnId
+		const scoped = params.parentTurnId
 			? parentRecorder?.scopedToTurn(params.parentTurnId)
 			: undefined;
+		const revocable = scoped ? revocableRecorder(scoped) : undefined;
+		const checkpoints = revocable?.recorder;
 
 		// A budget bounds how long someone waits. With a handoff, or once the
 		// chain is already backgrounded, nobody is: expiry must not abort.
@@ -229,6 +232,7 @@ export class SubAgentRunner {
 		handedOff = true;
 		budget.detachFromParent();
 		detachParentProgress();
+		revocable?.revoke();
 		return {
 			report: HANDED_OFF_REPORT,
 			status: "backgrounded",
@@ -266,7 +270,7 @@ export class SubAgentRunner {
 			session: input.session,
 			bus: input.bus,
 			tools: [],
-			systemPrompt: input.params.definition.systemPrompt,
+			systemPrompt: subAgentSystemPrompt(input.params.definition.systemPrompt),
 			model: input.model,
 			memory: this.deps.memory,
 			memoryProfile: this.deps.memoryProfile,

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -141,6 +141,7 @@ export class SubAgentRunner {
 		// Closes over locals, not `params`, so the chain link a descendant keeps
 		// does not pin this run's prompt and permissions.
 		let handedOff = false;
+		const parentPermissions = params.parentPermissions;
 		const launchedInBackground = params.chainInBackground === true;
 		const backgroundChain: BackgroundChainState = {
 			get inBackground() {
@@ -167,11 +168,23 @@ export class SubAgentRunner {
 			trace: params.trace?.context,
 			lsp: this.deps.lsp,
 			checkpoints,
-			// interactive:false so a sub-agent "ask" auto-denies. Fall back to a
-			// locked-down context (not undefined) so a missing parent can't
-			// disable the gate.
-			permissions: params.parentPermissions
-				? { ...params.parentPermissions, interactive: false }
+			// interactive:false keeps the non-interactive read-only shortcut; an
+			// "ask" escalates to the interactive ancestor's prompt while the
+			// chain is foreground. Fall back to a locked-down context (not
+			// undefined) so a missing parent can't disable the gate.
+			permissions: parentPermissions
+				? {
+						...parentPermissions,
+						interactive: false,
+						escalate: () => {
+							if (backgroundChain.inBackground) return null;
+							if (parentPermissions.interactive) {
+								return params.parentAskUser ?? null;
+							}
+							return parentPermissions.escalate?.() ?? null;
+						},
+						promptHost: parentPermissions.promptHost ?? parentPermissions,
+					}
 				: { mode: "manual", rules: emptyRuleSet(), interactive: false },
 		};
 

--- a/src/core/agent/SubAgentRunner.ts
+++ b/src/core/agent/SubAgentRunner.ts
@@ -121,7 +121,7 @@ export class SubAgentRunner {
 		const noWaiter = params.parentInBackground === true;
 		const budget = RunBudget.start(
 			params.parentSignal,
-			params.definition.timeoutMs,
+			params.timeoutMs ?? params.definition.timeoutMs,
 			{ abortOnExpiry: !canHandOff && !noWaiter },
 		);
 

--- a/src/core/agent/SubAgentTypes.ts
+++ b/src/core/agent/SubAgentTypes.ts
@@ -40,6 +40,8 @@ export interface SubAgentRunParams {
 	prompt: string;
 	definition: AgentDefinition;
 	depth: number;
+	/** Per-call override of the definition's budget. */
+	timeoutMs?: number;
 	parentCwd: string;
 	parentSignal: AbortSignal;
 	parentBus?: EventBus;

--- a/src/core/agent/SubAgentTypes.ts
+++ b/src/core/agent/SubAgentTypes.ts
@@ -16,6 +16,7 @@ import type { PermissionContext } from "../permissions/types.ts";
 import type { SpawnedAgent } from "../tools/AgentToolOutput.ts";
 import type { Tool } from "../tools/Tool.ts";
 import type {
+	AskUserFn,
 	BackgroundChainState,
 	ToolTraceContext,
 } from "../tools/ToolContext.ts";
@@ -75,6 +76,7 @@ export interface SubAgentRunParams {
 	 */
 	checkpoints?: CheckpointRecorder;
 	parentPermissions?: PermissionContext;
+	parentAskUser?: AskUserFn;
 	/** This run itself was launched in the background. */
 	chainInBackground?: boolean;
 	/**

--- a/src/core/agent/SubAgentTypes.ts
+++ b/src/core/agent/SubAgentTypes.ts
@@ -13,6 +13,7 @@ import type { CheckpointRecorder } from "../checkpoints/CheckpointStore.ts";
 import type { HookController } from "../hooks/index.ts";
 import type { LspService } from "../lsp/index.ts";
 import type { PermissionContext } from "../permissions/types.ts";
+import type { SpawnedAgent } from "../tools/AgentToolOutput.ts";
 import type { Tool } from "../tools/Tool.ts";
 import type { ToolTraceContext } from "../tools/ToolContext.ts";
 
@@ -37,7 +38,6 @@ export interface SubAgentRunnerDeps {
 
 export interface SubAgentRunParams {
 	prompt: string;
-	/** Resolved agent this run executes as; supplies prompt, model, and limits. */
 	definition: AgentDefinition;
 	depth: number;
 	parentCwd: string;
@@ -56,6 +56,11 @@ export interface SubAgentRunParams {
 	 */
 	checkpoints?: CheckpointRecorder;
 	parentPermissions?: PermissionContext;
+	/** The spawner is already in the background, so nobody is waiting on this run. */
+	parentInBackground?: boolean;
+	chainInBackground?: boolean;
+	/** Return a handle to background the run; undefined stops and summarizes it. */
+	onDeadline?: (handoff: DeadlineHandoff) => { runId: string } | undefined;
 	trace?: {
 		sessionId: string;
 		context: ToolTraceContext;
@@ -63,12 +68,20 @@ export interface SubAgentRunParams {
 	};
 }
 
-/** Turn outcomes plus budget expiry, which reports partial progress. */
-export type SubAgentStatus = TurnStatus | "timed_out";
+export type SubAgentStatus = TurnStatus | "timed_out" | "backgrounded";
+
+export interface DeadlineHandoff {
+	continuation: Promise<SubAgentResult>;
+	/** Stops it. The only way to end a run once the turn no longer owns it. */
+	cancel: () => void;
+}
 
 export interface SubAgentResult {
 	report: string;
 	status: SubAgentStatus;
 	usage: UsageInfo;
 	toolRounds: number;
+	runId?: string;
+	logPath?: string;
+	children?: SpawnedAgent[];
 }

--- a/src/core/agent/SubAgentTypes.ts
+++ b/src/core/agent/SubAgentTypes.ts
@@ -15,11 +15,16 @@ import type { LspService } from "../lsp/index.ts";
 import type { PermissionContext } from "../permissions/types.ts";
 import type { SpawnedAgent } from "../tools/AgentToolOutput.ts";
 import type { Tool } from "../tools/Tool.ts";
-import type { ToolTraceContext } from "../tools/ToolContext.ts";
+import type {
+	BackgroundChainState,
+	ToolTraceContext,
+} from "../tools/ToolContext.ts";
 
 export type SubAgentToolFactory = (opts: {
 	depth: number;
 	definition: AgentDefinition;
+	/** The model the run's turns go to: the definition's override, else the session's. */
+	model: ModelRef;
 }) => Tool[];
 
 export interface SubAgentRunnerDeps {
@@ -27,10 +32,22 @@ export interface SubAgentRunnerDeps {
 	getModel: () => ModelRef;
 	memory: MemoryMode;
 	memoryProfile: MemoryProfile;
-	getThinking: () => Promise<ThinkingConfig | null | undefined>;
-	getThinkingResolver?: () => Promise<RuntimeThinkingResolver>;
+	/**
+	 * Thinking and tool capability both belong to the model the run's turns
+	 * actually go to, which a definition's `model:` overrides — so the resolved
+	 * model is passed in rather than read from the session. `signal` must
+	 * cancel any lookup, or a run's budget cannot bound it.
+	 */
+	getThinking: (
+		model: ModelRef,
+		signal: AbortSignal,
+	) => Promise<ThinkingConfig | null | undefined>;
+	getThinkingResolver?: (
+		model: ModelRef,
+		signal: AbortSignal,
+	) => Promise<RuntimeThinkingResolver>;
 	toolFactory: SubAgentToolFactory;
-	isToolEnabled?: (name: string) => boolean;
+	isToolEnabled?: (name: string, model: ModelRef) => boolean;
 	hookController?: HookController;
 	lsp?: LspService;
 	checkpoints?: CheckpointRecorder;
@@ -58,9 +75,14 @@ export interface SubAgentRunParams {
 	 */
 	checkpoints?: CheckpointRecorder;
 	parentPermissions?: PermissionContext;
-	/** The spawner is already in the background, so nobody is waiting on this run. */
-	parentInBackground?: boolean;
+	/** This run itself was launched in the background. */
 	chainInBackground?: boolean;
+	/**
+	 * The spawner's chain state, read live: once it is in the background
+	 * nobody waits on this run, so its budget stops aborting — even if the
+	 * handoff above happens while this run is underway.
+	 */
+	parentChain?: BackgroundChainState;
 	/** Return a handle to background the run; undefined stops and summarizes it. */
 	onDeadline?: (handoff: DeadlineHandoff) => { runId: string } | undefined;
 	trace?: {

--- a/src/core/agent/SubAgentTypes.ts
+++ b/src/core/agent/SubAgentTypes.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../config/defaults.ts";
 import type { RuntimeThinkingResolver } from "../../config/thinkingRuntime.ts";
 import type { AgentClient } from "../../providers/AgentClient.ts";
+import type { AgentDefinition } from "../agents/AgentDefinition.ts";
 import type { EventBus } from "../bus/EventBus.ts";
 import type { TurnStatus, UsageInfo } from "../bus/events.ts";
 import type { CheckpointRecorder } from "../checkpoints/CheckpointStore.ts";
@@ -15,7 +16,10 @@ import type { PermissionContext } from "../permissions/types.ts";
 import type { Tool } from "../tools/Tool.ts";
 import type { ToolTraceContext } from "../tools/ToolContext.ts";
 
-export type SubAgentToolFactory = (opts: { depth: number }) => Tool[];
+export type SubAgentToolFactory = (opts: {
+	depth: number;
+	definition: AgentDefinition;
+}) => Tool[];
 
 export interface SubAgentRunnerDeps {
 	client: AgentClient;
@@ -24,7 +28,6 @@ export interface SubAgentRunnerDeps {
 	memoryProfile: MemoryProfile;
 	getThinking: () => Promise<ThinkingConfig | null | undefined>;
 	getThinkingResolver?: () => Promise<RuntimeThinkingResolver>;
-	systemPrompt: string;
 	toolFactory: SubAgentToolFactory;
 	isToolEnabled?: (name: string) => boolean;
 	hookController?: HookController;
@@ -34,6 +37,8 @@ export interface SubAgentRunnerDeps {
 
 export interface SubAgentRunParams {
 	prompt: string;
+	/** Resolved agent this run executes as; supplies prompt, model, and limits. */
+	definition: AgentDefinition;
 	depth: number;
 	parentCwd: string;
 	parentSignal: AbortSignal;
@@ -58,9 +63,12 @@ export interface SubAgentRunParams {
 	};
 }
 
+/** Turn outcomes plus budget expiry, which reports partial progress. */
+export type SubAgentStatus = TurnStatus | "timed_out";
+
 export interface SubAgentResult {
 	report: string;
-	status: TurnStatus;
+	status: SubAgentStatus;
 	usage: UsageInfo;
 	toolRounds: number;
 }

--- a/src/core/agent/rlm/RLMLoop.ts
+++ b/src/core/agent/rlm/RLMLoop.ts
@@ -48,8 +48,10 @@ export class RLMLoop {
 	private readonly maxLLMCalls: number;
 	private readonly maxOutputChars: number;
 	private readonly timeoutSummaryMs: number;
+	private readonly instructions: string;
 
 	constructor(private readonly deps: RLMDeps) {
+		this.instructions = deps.instructions?.trim() ?? "";
 		this.maxIterations = deps.maxIterations ?? DEFAULT_RLM_MAX_ITERATIONS;
 		this.maxLLMCalls = deps.maxLLMCalls ?? DEFAULT_RLM_MAX_LLM_CALLS;
 		this.maxOutputChars = deps.maxOutputChars ?? DEFAULT_RLM_MAX_OUTPUT_CHARS;
@@ -261,14 +263,16 @@ export class RLMLoop {
 		nativeToolError?: string;
 	}> {
 		const resp = await this.completeRaw({
-			content: rlmActionPrompt({
-				prompt: input.prompt,
-				variables: input.variables,
-				trajectory: input.trajectory,
-				iteration: input.iteration,
-				maxIterations: this.maxIterations,
-				maxOutputChars: this.maxOutputChars,
-			}),
+			content: this.withInstructions(
+				rlmActionPrompt({
+					prompt: input.prompt,
+					variables: input.variables,
+					trajectory: input.trajectory,
+					iteration: input.iteration,
+					maxIterations: this.maxIterations,
+					maxOutputChars: this.maxOutputChars,
+				}),
+			),
 			threadId: input.threadId || undefined,
 			usage: input.usage,
 			signal: input.signal,
@@ -300,7 +304,9 @@ export class RLMLoop {
 		signal?: AbortSignal;
 	}): Promise<string> {
 		const resp = await this.completeRaw({
-			content: rlmExtractPrompt(input.prompt, input.trajectory),
+			content: this.withInstructions(
+				rlmExtractPrompt(input.prompt, input.trajectory),
+			),
 			usage: input.usage,
 			signal: input.signal,
 		});
@@ -322,12 +328,14 @@ export class RLMLoop {
 			return "RLM run cancelled before completion.";
 		try {
 			const resp = await this.completeRaw({
-				content: rlmTimedOutSummaryPrompt({
-					prompt: input.prompt,
-					trajectory: input.trajectory,
-					timeoutMs: input.timeoutMs,
-					reason: input.reason,
-				}),
+				content: this.withInstructions(
+					rlmTimedOutSummaryPrompt({
+						prompt: input.prompt,
+						trajectory: input.trajectory,
+						timeoutMs: input.timeoutMs,
+						reason: input.reason,
+					}),
+				),
 				usage: input.usage,
 				signal: input.signal,
 			});
@@ -343,6 +351,10 @@ export class RLMLoop {
 				return "RLM run cancelled before completion.";
 			return `RLM timed out after ${Math.ceil(input.timeoutMs / 1000)} seconds before producing a summary: ${errorMessage(err)}`;
 		}
+	}
+
+	private withInstructions(content: string): string {
+		return this.instructions ? `${this.instructions}\n\n${content}` : content;
 	}
 
 	private async completeText(input: {

--- a/src/core/agent/rlm/RLMLoop.ts
+++ b/src/core/agent/rlm/RLMLoop.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../../providers/backboard/types.ts";
 import { errorMessage } from "../../../utils/errors.ts";
 import type { UsageInfo } from "../../bus/events.ts";
+import { RunBudget } from "../RunBudget.ts";
 import {
 	DEFAULT_RLM_MAX_ITERATIONS,
 	DEFAULT_RLM_MAX_LLM_CALLS,
@@ -59,7 +60,7 @@ export class RLMLoop {
 	async run(params: RLMRunParams): Promise<RLMResult> {
 		const usage: Required<UsageInfo> = blankUsage();
 		const trajectory: RLMTrajectoryEntry[] = [];
-		const budget = RLMBudget.start(params.signal, params.timeoutMs);
+		const budget = RunBudget.start(params.signal, params.timeoutMs);
 		let llmCallCount = 0;
 		const reserveLLMCalls = (count: number): void => {
 			budget.throwIfExpired();
@@ -418,83 +419,4 @@ function buildRunVariables(prompt: string, variables?: JSONObject): JSONObject {
 		task: prompt,
 		...(variables ?? {}),
 	};
-}
-
-class RLMTimeoutError extends Error {
-	constructor(timeoutMs: number) {
-		super(`RLM timed out after ${Math.ceil(timeoutMs / 1000)} seconds`);
-		this.name = "RLMTimeoutError";
-	}
-}
-
-class RLMBudget {
-	private readonly controller = new AbortController();
-	private readonly timeout: ReturnType<typeof setTimeout> | null = null;
-	private readonly abortFromParent: () => void;
-	private readonly deadlineMs: number;
-	private timedOut = false;
-
-	private constructor(
-		private readonly parentSignal: AbortSignal,
-		readonly timeoutMs?: number,
-	) {
-		this.deadlineMs =
-			timeoutMs === undefined
-				? Number.POSITIVE_INFINITY
-				: Date.now() + timeoutMs;
-		this.abortFromParent = (): void => {
-			this.controller.abort(parentSignal.reason);
-		};
-		if (parentSignal.aborted) {
-			this.abortFromParent();
-		} else {
-			parentSignal.addEventListener("abort", this.abortFromParent, {
-				once: true,
-			});
-		}
-
-		if (timeoutMs !== undefined) {
-			this.timeout = setTimeout(() => {
-				this.timedOut = true;
-				this.controller.abort(new RLMTimeoutError(timeoutMs));
-			}, timeoutMs);
-		}
-	}
-
-	static start(parentSignal: AbortSignal, timeoutMs?: number): RLMBudget {
-		return new RLMBudget(parentSignal, timeoutMs);
-	}
-
-	get signal(): AbortSignal {
-		return this.controller.signal;
-	}
-
-	get remainingMs(): number | undefined {
-		if (this.timeoutMs === undefined) return undefined;
-		if (this.timedOut) return 1;
-		return Math.max(1, this.deadlineMs - Date.now());
-	}
-
-	throwIfExpired(): void {
-		if (this.timedOut) {
-			throw new RLMTimeoutError(this.timeoutMs ?? 0);
-		}
-		if (this.signal.aborted && !this.parentSignal.aborted) {
-			throw this.signal.reason instanceof Error
-				? this.signal.reason
-				: new RLMTimeoutError(this.timeoutMs ?? 0);
-		}
-	}
-
-	isTimeoutError(error: Error): boolean {
-		return (
-			error instanceof RLMTimeoutError ||
-			(!this.parentSignal.aborted && this.signal.aborted && this.timedOut)
-		);
-	}
-
-	dispose(): void {
-		if (this.timeout) clearTimeout(this.timeout);
-		this.parentSignal.removeEventListener("abort", this.abortFromParent);
-	}
 }

--- a/src/core/agent/rlm/RLMTypes.ts
+++ b/src/core/agent/rlm/RLMTypes.ts
@@ -17,6 +17,7 @@ export interface RLMDeps {
 	client: Pick<AgentClient, "sendMessage">;
 	model: ModelRef;
 	executor: REPLExecutor;
+	instructions?: string;
 	maxIterations?: number;
 	maxLLMCalls?: number;
 	maxOutputChars?: number;

--- a/src/core/agents/AgentCatalog.ts
+++ b/src/core/agents/AgentCatalog.ts
@@ -1,0 +1,41 @@
+import type { AgentDefinition } from "./AgentDefinition.ts";
+
+/**
+ * The resolved set of agents `subagent_type` accepts. Callers pass definitions
+ * in precedence order (project, then user, then built-in); the catalog keeps
+ * the first entry for each name and drops the rest, so lookups, `names`, and
+ * `promptCatalog` always agree.
+ */
+export class AgentCatalog {
+	readonly agents: readonly AgentDefinition[];
+	readonly warnings: readonly string[];
+	private readonly byName: ReadonlyMap<string, AgentDefinition>;
+
+	constructor(
+		agents: readonly AgentDefinition[],
+		warnings: readonly string[] = [],
+	) {
+		const byName = new Map<string, AgentDefinition>();
+		for (const agent of agents) {
+			if (!byName.has(agent.name)) byName.set(agent.name, agent);
+		}
+		this.agents = [...byName.values()];
+		this.warnings = warnings;
+		this.byName = byName;
+	}
+
+	get(name: string): AgentDefinition | undefined {
+		return this.byName.get(name);
+	}
+
+	get names(): string[] {
+		return this.agents.map((agent) => agent.name);
+	}
+
+	/** Markdown list injected into the Agent tool description. */
+	get promptCatalog(): string {
+		return this.agents
+			.map((agent) => `- \`${agent.name}\`: ${agent.description}`)
+			.join("\n");
+	}
+}

--- a/src/core/agents/AgentDefinition.ts
+++ b/src/core/agents/AgentDefinition.ts
@@ -1,0 +1,24 @@
+import type { ModelRef } from "../../config/defaults.ts";
+import type { AgentMode } from "../tools/AgentToolOutput.ts";
+
+export type AgentSource = "built-in" | "project" | "user";
+
+export interface AgentDefinition {
+	name: string;
+	description: string;
+	mode: AgentMode;
+	/** Replaces the default sub-agent system prompt. */
+	systemPrompt: string;
+	/** Allowlist of delegatable tool names; undefined inherits the parent's set. */
+	tools?: readonly string[];
+	disallowedTools?: readonly string[];
+	/** Overrides the parent's model for this agent's turns. */
+	model?: ModelRef;
+	maxRounds?: number;
+	/** Wall-clock budget for one run; on expiry the agent summarizes partial work. */
+	timeoutMs?: number;
+	/** Run past the spawning turn and report back later. Top-level worker spawns only. */
+	background?: boolean;
+	source: AgentSource;
+	path?: string;
+}

--- a/src/core/agents/builtin.ts
+++ b/src/core/agents/builtin.ts
@@ -22,7 +22,7 @@ export const BUILT_IN_AGENTS: readonly AgentDefinition[] = [
 		description:
 			"Analyzes the prompt and provided variables in a JavaScript REPL.",
 		mode: "rlm",
-		systemPrompt: subagent.prompt,
+		systemPrompt: "",
 		source: "built-in",
 	},
 ];

--- a/src/core/agents/builtin.ts
+++ b/src/core/agents/builtin.ts
@@ -1,0 +1,28 @@
+import { subagent } from "../../prompts/system/subagent.tsx";
+import type { AgentDefinition } from "./AgentDefinition.ts";
+
+export const WORKER_AGENT_NAME = "worker";
+export const RLM_AGENT_NAME = "rlm";
+
+/**
+ * The two modes that existed before the registry. They stay built in so
+ * `subagent_type` keeps accepting them when no agent files are present.
+ */
+export const BUILT_IN_AGENTS: readonly AgentDefinition[] = [
+	{
+		name: WORKER_AGENT_NAME,
+		description:
+			"Tool-using sub-agent that works over the project and returns a report.",
+		mode: "worker",
+		systemPrompt: subagent.prompt,
+		source: "built-in",
+	},
+	{
+		name: RLM_AGENT_NAME,
+		description:
+			"Analyzes the prompt and provided variables in a JavaScript REPL.",
+		mode: "rlm",
+		systemPrompt: subagent.prompt,
+		source: "built-in",
+	},
+];

--- a/src/core/agents/discovery.ts
+++ b/src/core/agents/discovery.ts
@@ -1,0 +1,97 @@
+import { type Dirent, existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { qProjectAgentsDir, qUserAgentsDir } from "../../config/paths.ts";
+import { errorMessage } from "../../utils/errors.ts";
+import { AgentCatalog } from "./AgentCatalog.ts";
+import type { AgentDefinition, AgentSource } from "./AgentDefinition.ts";
+import { BUILT_IN_AGENTS } from "./builtin.ts";
+import { type AgentLoadResult, parseAgentFromMarkdown } from "./parse.ts";
+
+export interface DiscoverAgentsOptions {
+	cwd: string;
+	homeDir?: string;
+	includeProjectAgents?: boolean;
+	includeUserAgents?: boolean;
+}
+
+/**
+ * Loads `<repo>/.backboard/agents/*.md` then `~/.backboard/agents/*.md`.
+ * Project files shadow user files of the same name; both shadow built-ins.
+ */
+export async function discoverAgents(
+	options: DiscoverAgentsOptions,
+): Promise<AgentCatalog> {
+	const warnings: string[] = [];
+	const agents: AgentDefinition[] = [];
+	const seen = new Map<string, AgentDefinition>();
+
+	const add = (result: AgentLoadResult): void => {
+		if (result.warning) warnings.push(result.warning);
+		if (!result.agent) return;
+		const existing = seen.get(result.agent.name);
+		if (existing) {
+			warnings.push(
+				`Skipped duplicate agent '${result.agent.name}' at ${result.agent.path}; already loaded from ${existing.path ?? existing.source}.`,
+			);
+			return;
+		}
+		seen.set(result.agent.name, result.agent);
+		agents.push(result.agent);
+	};
+
+	if (options.includeProjectAgents !== false) {
+		const root = qProjectAgentsDir(path.resolve(options.cwd));
+		for (const result of await loadAgentRoot(root, "project")) add(result);
+	}
+
+	if (options.includeUserAgents !== false) {
+		const root = qUserAgentsDir(options.homeDir);
+		for (const result of await loadAgentRoot(root, "user")) add(result);
+	}
+
+	for (const builtIn of BUILT_IN_AGENTS) {
+		if (seen.has(builtIn.name)) continue;
+		seen.set(builtIn.name, builtIn);
+		agents.push(builtIn);
+	}
+
+	return new AgentCatalog(agents, warnings);
+}
+
+async function loadAgentRoot(
+	root: string,
+	source: AgentSource,
+): Promise<AgentLoadResult[]> {
+	if (!existsSync(root)) return [];
+
+	let entries: Dirent[];
+	try {
+		entries = await readdir(root, { withFileTypes: true });
+	} catch (err) {
+		return [{ warning: `Skipped agents root ${root}: ${errorMessage(err)}.` }];
+	}
+	entries.sort((a, b) => a.name.localeCompare(b.name));
+
+	const results: AgentLoadResult[] = [];
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+		const filePath = path.join(root, entry.name);
+		try {
+			const content = await readFile(filePath, "utf8");
+			results.push(
+				parseAgentFromMarkdown(
+					content,
+					path.basename(entry.name, ".md"),
+					filePath,
+					source,
+				),
+			);
+		} catch (err) {
+			results.push({
+				warning: `Skipped agent at ${filePath}: ${errorMessage(err)}.`,
+			});
+		}
+	}
+	return results;
+}

--- a/src/core/agents/index.ts
+++ b/src/core/agents/index.ts
@@ -1,0 +1,9 @@
+export { AgentCatalog } from "./AgentCatalog.ts";
+export type { AgentDefinition, AgentSource } from "./AgentDefinition.ts";
+export {
+	BUILT_IN_AGENTS,
+	RLM_AGENT_NAME,
+	WORKER_AGENT_NAME,
+} from "./builtin.ts";
+export { type DiscoverAgentsOptions, discoverAgents } from "./discovery.ts";
+export { type AgentLoadResult, parseAgentFromMarkdown } from "./parse.ts";

--- a/src/core/agents/parse.ts
+++ b/src/core/agents/parse.ts
@@ -53,7 +53,7 @@ export function parseAgentFromMarkdown(
 	const description = stringValue(data.description);
 	if (!description) return skip("missing description.");
 	if (description.length > MAX_DESCRIPTION_LENGTH) {
-		return skip("description exceeds 1024 characters.");
+		return skip(`description exceeds ${MAX_DESCRIPTION_LENGTH} characters.`);
 	}
 
 	const mode = parseMode(data.mode);
@@ -83,6 +83,9 @@ export function parseAgentFromMarkdown(
 
 	const background = boolValue(data.background);
 	if (background === INVALID) return skip("background must be a boolean.");
+	if (background && mode === "rlm") {
+		return skip("background is not supported for rlm agents.");
+	}
 
 	return {
 		agent: {

--- a/src/core/agents/parse.ts
+++ b/src/core/agents/parse.ts
@@ -70,7 +70,7 @@ export function parseAgentFromMarkdown(
 	const model = parseModelRef(data.model);
 	if (model === INVALID) {
 		return skip(
-			`invalid model '${stringValue(data.model)}' — use a model name, 'provider/model' with both parts set, or 'inherit'.`,
+			`invalid model '${describeValue(data.model)}' — use a model name, 'provider/model' with both parts set, or 'inherit'.`,
 		);
 	}
 
@@ -112,8 +112,13 @@ const INVALID = Symbol("invalid");
 type Invalid = typeof INVALID;
 
 function parseModelRef(value: unknown): ModelRef | undefined | Invalid {
+	// Only an absent field and the literal "inherit" mean "no override": an
+	// explicit non-string (or blank) value is a typo, not a request to fall
+	// back to the session model, so it must warn instead of loading silently.
+	if (value === undefined) return undefined;
 	const raw = stringValue(value);
-	if (!raw || raw === "inherit") return undefined;
+	if (!raw) return INVALID;
+	if (raw === "inherit") return undefined;
 	const parsed = parseModel(raw);
 	const provider = parsed.provider.trim();
 	const model = parsed.model.trim();
@@ -154,6 +159,16 @@ function boolValue(value: unknown): boolean | undefined | Invalid {
 
 function stringValue(value: unknown): string | null {
 	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/** Renders any frontmatter value for a warning, including non-strings. */
+function describeValue(value: unknown): string {
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/core/agents/parse.ts
+++ b/src/core/agents/parse.ts
@@ -1,0 +1,145 @@
+import { parseDocument } from "yaml";
+import { parseModel } from "../../config/defaults.ts";
+import type { AgentMode } from "../tools/AgentToolOutput.ts";
+import type { AgentDefinition, AgentSource } from "./AgentDefinition.ts";
+
+const AGENT_NAME_PATTERN = /^[a-z0-9-]+$/;
+const MAX_AGENT_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/;
+
+export interface AgentLoadResult {
+	agent?: AgentDefinition;
+	warning?: string;
+}
+
+export function parseAgentFromMarkdown(
+	content: string,
+	fileStem: string,
+	filePath: string,
+	source: AgentSource,
+): AgentLoadResult {
+	const skip = (reason: string): AgentLoadResult => ({
+		warning: `Skipped agent at ${filePath}: ${reason}`,
+	});
+
+	const parsed = FRONTMATTER_PATTERN.exec(content);
+	if (!parsed) return skip("missing YAML frontmatter.");
+
+	const doc = parseDocument(parsed[1] ?? "");
+	if (doc.errors.length > 0) return skip("invalid YAML frontmatter.");
+
+	const data = doc.toJSON() as unknown;
+	if (!isRecord(data)) return skip("frontmatter must be a map.");
+
+	const body = (parsed[2] ?? "").trim();
+	if (!body) return skip("missing system prompt body.");
+
+	// Names are matched exactly by subagent_type, so the rule is stated rather
+	// than normalized: silently lowercasing would make Researcher.md and
+	// researcher.md collide on one name.
+	const name = stringValue(data.name) ?? fileStem;
+	if (name.length > MAX_AGENT_NAME_LENGTH) {
+		return skip(
+			`agent name '${name}' exceeds ${MAX_AGENT_NAME_LENGTH} characters.`,
+		);
+	}
+	if (!AGENT_NAME_PATTERN.test(name)) {
+		return skip(
+			`invalid agent name '${name}' — use lowercase letters, digits, and hyphens only (rename the file, or set a 'name:' in frontmatter).`,
+		);
+	}
+
+	const description = stringValue(data.description);
+	if (!description) return skip("missing description.");
+	if (description.length > MAX_DESCRIPTION_LENGTH) {
+		return skip("description exceeds 1024 characters.");
+	}
+
+	const mode = parseMode(data.mode);
+	if (!mode) return skip('mode must be "worker" or "rlm".');
+
+	const tools = stringList(data.tools);
+	if (tools === INVALID) return skip("tools must be a list of strings.");
+
+	const disallowedTools = stringList(data.disallowedTools);
+	if (disallowedTools === INVALID) {
+		return skip("disallowedTools must be a list of strings.");
+	}
+
+	const modelValue = stringValue(data.model);
+	const model =
+		modelValue && modelValue !== "inherit" ? parseModel(modelValue) : undefined;
+
+	const maxRounds = positiveInt(data.maxRounds);
+	if (maxRounds === INVALID) {
+		return skip("maxRounds must be a positive integer.");
+	}
+
+	const timeoutMs = positiveInt(data.timeoutMs);
+	if (timeoutMs === INVALID) {
+		return skip("timeoutMs must be a positive integer.");
+	}
+
+	const background = boolValue(data.background);
+	if (background === INVALID) return skip("background must be a boolean.");
+
+	return {
+		agent: {
+			name,
+			description,
+			mode,
+			systemPrompt: body,
+			...(tools ? { tools } : {}),
+			...(disallowedTools ? { disallowedTools } : {}),
+			...(model ? { model } : {}),
+			...(maxRounds !== undefined ? { maxRounds } : {}),
+			...(timeoutMs !== undefined ? { timeoutMs } : {}),
+			...(background !== undefined ? { background } : {}),
+			source,
+			path: filePath,
+		},
+	};
+}
+
+const INVALID = Symbol("invalid");
+type Invalid = typeof INVALID;
+
+function parseMode(value: unknown): AgentMode | null {
+	if (value === undefined) return "worker";
+	const mode = stringValue(value);
+	return mode === "worker" || mode === "rlm" ? mode : null;
+}
+
+function stringList(value: unknown): string[] | undefined | Invalid {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) return INVALID;
+	const items: string[] = [];
+	for (const item of value) {
+		const parsed = stringValue(item);
+		if (!parsed) return INVALID;
+		items.push(parsed);
+	}
+	return items;
+}
+
+function positiveInt(value: unknown): number | undefined | Invalid {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+		return INVALID;
+	}
+	return value;
+}
+
+function boolValue(value: unknown): boolean | undefined | Invalid {
+	if (value === undefined) return undefined;
+	return typeof value === "boolean" ? value : INVALID;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/agents/parse.ts
+++ b/src/core/agents/parse.ts
@@ -1,5 +1,5 @@
 import { parseDocument } from "yaml";
-import { parseModel } from "../../config/defaults.ts";
+import { type ModelRef, parseModel } from "../../config/defaults.ts";
 import type { AgentMode } from "../tools/AgentToolOutput.ts";
 import type { AgentDefinition, AgentSource } from "./AgentDefinition.ts";
 
@@ -67,9 +67,12 @@ export function parseAgentFromMarkdown(
 		return skip("disallowedTools must be a list of strings.");
 	}
 
-	const modelValue = stringValue(data.model);
-	const model =
-		modelValue && modelValue !== "inherit" ? parseModel(modelValue) : undefined;
+	const model = parseModelRef(data.model);
+	if (model === INVALID) {
+		return skip(
+			`invalid model '${stringValue(data.model)}' — use a model name, 'provider/model' with both parts set, or 'inherit'.`,
+		);
+	}
 
 	const maxRounds = positiveInt(data.maxRounds);
 	if (maxRounds === INVALID) {
@@ -107,6 +110,16 @@ export function parseAgentFromMarkdown(
 
 const INVALID = Symbol("invalid");
 type Invalid = typeof INVALID;
+
+function parseModelRef(value: unknown): ModelRef | undefined | Invalid {
+	const raw = stringValue(value);
+	if (!raw || raw === "inherit") return undefined;
+	const parsed = parseModel(raw);
+	const provider = parsed.provider.trim();
+	const model = parsed.model.trim();
+	if (!provider || !model) return INVALID;
+	return { provider, model };
+}
 
 function parseMode(value: unknown): AgentMode | null {
 	if (value === undefined) return "worker";

--- a/src/core/bus/events.ts
+++ b/src/core/bus/events.ts
@@ -9,12 +9,12 @@ export type TurnStatus =
 	| "failed"
 	| "cancelled";
 
-/** A sub-agent running past the turn that spawned it. */
 export interface BackgroundRunSnapshot {
 	id: string;
 	agent: string;
 	label: string;
-	status: "running" | TurnStatus | "timed_out";
+	status: "running" | TurnStatus | "timed_out" | "backgrounded";
+	adopted?: boolean;
 	startedAt: number;
 	finishedAt?: number;
 	rounds: number;

--- a/src/core/bus/events.ts
+++ b/src/core/bus/events.ts
@@ -9,6 +9,17 @@ export type TurnStatus =
 	| "failed"
 	| "cancelled";
 
+/** A sub-agent running past the turn that spawned it. */
+export interface BackgroundRunSnapshot {
+	id: string;
+	agent: string;
+	label: string;
+	status: "running" | TurnStatus | "timed_out";
+	startedAt: number;
+	finishedAt?: number;
+	rounds: number;
+}
+
 export interface ToolCallRef {
 	id: string;
 	name: string;
@@ -122,6 +133,8 @@ export type AgentEvent =
 			status: "done" | "error";
 	  }
 	| ToolResultEvent
+	| { type: "agent:background_started"; run: BackgroundRunSnapshot }
+	| { type: "agent:background_finished"; run: BackgroundRunSnapshot }
 	| { type: "tool:error"; toolCallId: string; name: string; error: string }
 	| {
 			type: "turn:end";

--- a/src/core/checkpoints/CheckpointManager.ts
+++ b/src/core/checkpoints/CheckpointManager.ts
@@ -4,6 +4,7 @@ import {
 	sessionPathsForRoot,
 } from "../session/SessionStore.ts";
 import {
+	type CapturedEntry,
 	type CheckpointCallContext,
 	type CheckpointRecorder,
 	CheckpointStore,
@@ -98,6 +99,10 @@ export class CheckpointManager implements CheckpointRecorder {
 		contentIfInMemory?: Uint8Array,
 	): Promise<void> {
 		return this.active.recordPostImage(absPath, ctx, contentIfInMemory);
+	}
+
+	revokeCapture(entry: CapturedEntry): Promise<void> {
+		return this.active.revokeCapture(entry);
 	}
 
 	revertToolCall(toolCallId: string): Promise<void> {

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -612,9 +612,6 @@ export class CheckpointStore implements CheckpointRecorder {
 		const before = this.shellBegins.get(callKey);
 		this.shellBegins.delete(callKey);
 		if (!before) return;
-		// Revoked before the walk: the snapshot is released above, and nothing
-		// this command changed may be journaled, so skip the re-scan.
-		if (ctx.mayJournal?.() === false) return;
 		try {
 			const after = await this.shellIndex.refresh(this.blobs, {
 				storeBlobs: true,
@@ -624,7 +621,7 @@ export class CheckpointStore implements CheckpointRecorder {
 				return;
 			}
 			this.shellLastStored = { snapshot: after, at: performance.now() };
-			// Revoked mid-walk: keep the refreshed baseline, journal nothing.
+			// Revoked: keep the refreshed baseline, journal nothing.
 			if (ctx.mayJournal?.() === false) return;
 			const diff = this.shellIndex.diff(before, after);
 			const changes = [...diff.created, ...diff.modified, ...diff.deleted];

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -98,26 +98,33 @@ export interface RevocableRecorder {
 export function revocableRecorder(
 	recorder: CheckpointRecorder,
 ): RevocableRecorder {
-	let live = true;
-	const noop = async (): Promise<void> => {};
+	const gate = { live: true };
 	return {
 		revoke: () => {
-			live = false;
+			gate.live = false;
 		},
-		recorder: {
-			recordPreImage: (...args) =>
-				live ? recorder.recordPreImage(...args) : noop(),
-			recordPostImage: (...args) =>
-				live ? recorder.recordPostImage(...args) : noop(),
-			revertToolCall: (...args) =>
-				live ? recorder.revertToolCall(...args) : noop(),
-			beginShellCapture: (...args) =>
-				live ? recorder.beginShellCapture(...args) : noop(),
-			endShellCapture: (...args) =>
-				live ? recorder.endShellCapture(...args) : noop(),
-			captureWarning: () => (live ? recorder.captureWarning() : null),
-			scopedToTurn: (turnId) => recorder.scopedToTurn(turnId),
-		},
+		recorder: gatedRecorder(recorder, gate),
+	};
+}
+
+function gatedRecorder(
+	recorder: CheckpointRecorder,
+	gate: { live: boolean },
+): CheckpointRecorder {
+	const noop = async (): Promise<void> => {};
+	return {
+		recordPreImage: (...args) =>
+			gate.live ? recorder.recordPreImage(...args) : noop(),
+		recordPostImage: (...args) =>
+			gate.live ? recorder.recordPostImage(...args) : noop(),
+		revertToolCall: (...args) => recorder.revertToolCall(...args),
+		beginShellCapture: (...args) =>
+			gate.live ? recorder.beginShellCapture(...args) : noop(),
+		endShellCapture: (...args) =>
+			gate.live ? recorder.endShellCapture(...args) : noop(),
+		captureWarning: () => (gate.live ? recorder.captureWarning() : null),
+		scopedToTurn: (turnId) =>
+			gatedRecorder(recorder.scopedToTurn(turnId), gate),
 	};
 }
 

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -86,6 +86,41 @@ export interface CheckpointRecorder {
 	scopedToTurn(turnId: string): CheckpointRecorder;
 }
 
+export interface RevocableRecorder {
+	recorder: CheckpointRecorder;
+	revoke: () => void;
+}
+
+/**
+ * Wraps a recorder so journaling can be switched off after contexts holding it
+ * have already been copied. Used when a run outlives the turn it was scoped to.
+ */
+export function revocableRecorder(
+	recorder: CheckpointRecorder,
+): RevocableRecorder {
+	let live = true;
+	const noop = async (): Promise<void> => {};
+	return {
+		revoke: () => {
+			live = false;
+		},
+		recorder: {
+			recordPreImage: (...args) =>
+				live ? recorder.recordPreImage(...args) : noop(),
+			recordPostImage: (...args) =>
+				live ? recorder.recordPostImage(...args) : noop(),
+			revertToolCall: (...args) =>
+				live ? recorder.revertToolCall(...args) : noop(),
+			beginShellCapture: (...args) =>
+				live ? recorder.beginShellCapture(...args) : noop(),
+			endShellCapture: (...args) =>
+				live ? recorder.endShellCapture(...args) : noop(),
+			captureWarning: () => (live ? recorder.captureWarning() : null),
+			scopedToTurn: (turnId) => recorder.scopedToTurn(turnId),
+		},
+	};
+}
+
 export function scopeCheckpointRecorder(
 	recorder: CheckpointRecorder,
 	turnId: string,

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -42,12 +42,24 @@ const REDO_TOOL = "redo-point";
 /** A begin walk is skipped when a storing refresh completed this recently. */
 const BEGIN_SKIP_FRESH_MS = 2_000;
 
+/** A journaled pre/skip entry, identified so a later revoke can drop it. */
+export interface CapturedEntry {
+	/** Root of the session whose journal holds the entry; `ref` is only meaningful there. */
+	journalRoot: string;
+	turnId: string;
+	/** `seq` of the journaled entry. */
+	ref: number;
+	path: string;
+}
+
 /** The slice of ToolContext the checkpoint engine needs at capture time. */
 export interface CheckpointCallContext {
 	turnId?: string;
 	toolCallId?: string;
 	/** Injected by revocable recorders; re-checked at commit time so an in-flight capture cannot journal after revocation. */
 	mayJournal?: () => boolean;
+	/** Injected by revocable recorders; reports a durable pre/skip entry whose write has not happened yet. */
+	onCaptured?: (entry: CapturedEntry) => void;
 }
 
 export interface RecordPreImageOptions {
@@ -78,6 +90,8 @@ export interface CheckpointRecorder {
 		ctx: CheckpointCallContext,
 		contentIfInMemory?: Uint8Array,
 	): Promise<void>;
+	/** Neutralizes an already-journaled pre/skip entry with a `revoke` record. */
+	revokeCapture(entry: CapturedEntry): Promise<void>;
 	revertToolCall(toolCallId: string): Promise<void>;
 	/** Snapshots the workspace before a shell command (never throws). */
 	beginShellCapture(cwd: string, ctx: CheckpointCallContext): Promise<void>;
@@ -90,7 +104,8 @@ export interface CheckpointRecorder {
 
 export interface RevocableRecorder {
 	recorder: CheckpointRecorder;
-	revoke: () => void;
+	/** Closes the gate and drops pre-images no post-image has settled. */
+	revoke: () => Promise<void>;
 }
 
 /**
@@ -101,43 +116,89 @@ export function revocableRecorder(
 	recorder: CheckpointRecorder,
 ): RevocableRecorder {
 	const gate = { live: true };
+	// Pre-images that are durable but whose write has not happened yet, keyed
+	// by capture. The write will now complete with its post-image suppressed;
+	// left alone, the turn's /undo would use the orphan pre-image to overwrite
+	// what the backgrounded run went on to write.
+	const pending = new Map<string, CapturedEntry>();
 	return {
-		revoke: () => {
+		revoke: async () => {
+			if (!gate.live) return;
 			gate.live = false;
+			// Best-effort, and every entry is attempted: the run has already been
+			// handed off by the time this runs, so a journal write failure must
+			// neither fail it nor leave the remaining entries in the checkpoint.
+			const entries = [...pending.values()];
+			pending.clear();
+			for (const entry of entries) {
+				await recorder.revokeCapture(entry).catch(() => {});
+			}
 		},
-		recorder: gatedRecorder(recorder, gate),
+		recorder: gatedRecorder(recorder, gate, pending),
 	};
 }
 
 function gatedRecorder(
 	recorder: CheckpointRecorder,
 	gate: { live: boolean },
+	pending: Map<string, CapturedEntry>,
 ): CheckpointRecorder {
 	const noop = async (): Promise<void> => {};
-	const gatedCtx = (ctx: CheckpointCallContext): CheckpointCallContext => ({
+	const captureKey = (ctx: CheckpointCallContext, absPath: string): string =>
+		`${ctx.toolCallId ?? "unknown"} ${resolve(absPath)}`;
+	const gatedCtx = (
+		ctx: CheckpointCallContext,
+		key: string,
+	): CheckpointCallContext => ({
 		...ctx,
 		mayJournal: () => gate.live && ctx.mayJournal?.() !== false,
+		onCaptured: (entry) => {
+			ctx.onCaptured?.(entry);
+			pending.set(key, entry);
+		},
 	});
 	return {
 		recordPreImage: (absPath, ctx, opts) => {
-			if (gate.live)
-				return recorder.recordPreImage(absPath, gatedCtx(ctx), opts);
+			if (gate.live) {
+				return recorder.recordPreImage(
+					absPath,
+					gatedCtx(ctx, captureKey(ctx, absPath)),
+					opts,
+				);
+			}
 			if (opts?.requireRevertible)
 				return Promise.reject(revokedCaptureError(absPath));
 			return noop();
 		},
-		recordPostImage: (absPath, ctx, contentIfInMemory) =>
-			gate.live
-				? recorder.recordPostImage(absPath, gatedCtx(ctx), contentIfInMemory)
-				: noop(),
+		recordPostImage: (absPath, ctx, contentIfInMemory) => {
+			// The write this reports has already happened. If its pre-image was
+			// captured while live, both belong to the turn: keep the pre-image
+			// and journal the post-image even if the gate closed in between, or
+			// /undo would either miss the write or restore it unchecked.
+			const key = captureKey(ctx, absPath);
+			if (pending.delete(key)) {
+				return recorder.recordPostImage(absPath, ctx, contentIfInMemory);
+			}
+			return gate.live
+				? recorder.recordPostImage(
+						absPath,
+						gatedCtx(ctx, key),
+						contentIfInMemory,
+					)
+				: noop();
+		},
+		revokeCapture: (entry) => recorder.revokeCapture(entry),
 		revertToolCall: (...args) => recorder.revertToolCall(...args),
 		beginShellCapture: (cwd, ctx) =>
-			gate.live ? recorder.beginShellCapture(cwd, gatedCtx(ctx)) : noop(),
-		endShellCapture: (ctx) =>
-			gate.live ? recorder.endShellCapture(gatedCtx(ctx)) : noop(),
+			gate.live ? recorder.beginShellCapture(cwd, gatedCtx(ctx, "")) : noop(),
+		// Delegated even after revocation: the injected `mayJournal` keeps the
+		// diff out of the journal, while the call still releases the workspace
+		// snapshot a live `beginShellCapture` allocated. Short-circuiting here
+		// would strand that snapshot for the rest of the session.
+		endShellCapture: (ctx) => recorder.endShellCapture(gatedCtx(ctx, "")),
 		captureWarning: () => (gate.live ? recorder.captureWarning() : null),
 		scopedToTurn: (turnId) =>
-			gatedRecorder(recorder.scopedToTurn(turnId), gate),
+			gatedRecorder(recorder.scopedToTurn(turnId), gate, pending),
 	};
 }
 
@@ -159,6 +220,7 @@ export function scopeCheckpointRecorder(
 			recorder.recordPreImage(absPath, { ...ctx, turnId }, opts),
 		recordPostImage: (absPath, ctx, contentIfInMemory) =>
 			recorder.recordPostImage(absPath, { ...ctx, turnId }, contentIfInMemory),
+		revokeCapture: (entry) => recorder.revokeCapture(entry),
 		revertToolCall: (toolCallId) => recorder.revertToolCall(toolCallId),
 		beginShellCapture: (cwd, ctx) =>
 			recorder.beginShellCapture(cwd, { ...ctx, turnId }),
@@ -358,15 +420,45 @@ export class CheckpointStore implements CheckpointRecorder {
 		// Write-ahead durability: the journal entry (and blob) must be on disk
 		// before the tool mutates the file. Flush errors abort the tool call.
 		await this.journal.flush();
+		const entry: CapturedEntry = {
+			journalRoot: this.paths.root,
+			turnId,
+			ref: entrySeq,
+			path,
+		};
 		// Revocation can still land while that flush is in flight. The entry is
 		// already durable and its post-image will now be suppressed, so drop it
 		// with a compensating record rather than leave an orphan pre-image the
 		// turn's /undo would use to revert the background run's write.
 		if (ctx.mayJournal?.() === false) {
-			this.append({ type: "revoke", turnId, ref: entrySeq, path });
-			await this.journal.flush();
+			await this.revokeCapture(entry);
 			if (opts?.requireRevertible) throw revokedCaptureError(path);
+			return;
 		}
+		// Still live, but the tool has not written yet. Hand the entry to the
+		// recorder so a revoke landing before the write can drop it too.
+		ctx.onCaptured?.(entry);
+	}
+
+	/**
+	 * Neutralizes an already-journaled pre/skip entry. Used when a run's
+	 * capture access is revoked after the entry became durable: its post-image
+	 * is suppressed from then on, so the orphan pre-image must not survive to
+	 * make /undo overwrite a write the turn no longer owns.
+	 */
+	async revokeCapture(entry: CapturedEntry): Promise<void> {
+		// A run can outlive a session switch (/new, /sessions) and revoke
+		// through the manager into whichever store is active by then; its seq
+		// means nothing here and would poison an unrelated record.
+		if (entry.journalRoot !== this.paths.root) return;
+		if (this.revokedSeqs.has(entry.ref)) return;
+		this.append({
+			type: "revoke",
+			turnId: entry.turnId,
+			ref: entry.ref,
+			path: entry.path,
+		});
+		await this.journal.flush();
 	}
 
 	/**
@@ -410,7 +502,9 @@ export class CheckpointStore implements CheckpointRecorder {
 		const byPath = new Map<string, PreImageJournalRecord>();
 		for (const record of this.records) {
 			if (record.type !== "pre" || record.toolCallId !== toolCallId) continue;
-			if (this.isRevoked(record)) continue;
+			// A revoked entry is still this tool call's own pre-image: revocation
+			// only detached it from the turn's checkpoint, and the rollback here
+			// only runs once every pre-image of the call has committed.
 			const key = this.pathKey(record.path);
 			if (!byPath.has(key)) byPath.set(key, record);
 		}
@@ -518,6 +612,9 @@ export class CheckpointStore implements CheckpointRecorder {
 		const before = this.shellBegins.get(callKey);
 		this.shellBegins.delete(callKey);
 		if (!before) return;
+		// Revoked before the walk: the snapshot is released above, and nothing
+		// this command changed may be journaled, so skip the re-scan.
+		if (ctx.mayJournal?.() === false) return;
 		try {
 			const after = await this.shellIndex.refresh(this.blobs, {
 				storeBlobs: true,

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -46,6 +46,8 @@ const BEGIN_SKIP_FRESH_MS = 2_000;
 export interface CheckpointCallContext {
 	turnId?: string;
 	toolCallId?: string;
+	/** Injected by revocable recorders; re-checked at commit time so an in-flight capture cannot journal after revocation. */
+	mayJournal?: () => boolean;
 }
 
 export interface RecordPreImageOptions {
@@ -112,20 +114,40 @@ function gatedRecorder(
 	gate: { live: boolean },
 ): CheckpointRecorder {
 	const noop = async (): Promise<void> => {};
+	const gatedCtx = (ctx: CheckpointCallContext): CheckpointCallContext => ({
+		...ctx,
+		mayJournal: () => gate.live && ctx.mayJournal?.() !== false,
+	});
 	return {
-		recordPreImage: (...args) =>
-			gate.live ? recorder.recordPreImage(...args) : noop(),
-		recordPostImage: (...args) =>
-			gate.live ? recorder.recordPostImage(...args) : noop(),
+		recordPreImage: (absPath, ctx, opts) => {
+			if (gate.live)
+				return recorder.recordPreImage(absPath, gatedCtx(ctx), opts);
+			if (opts?.requireRevertible)
+				return Promise.reject(revokedCaptureError(absPath));
+			return noop();
+		},
+		recordPostImage: (absPath, ctx, contentIfInMemory) =>
+			gate.live
+				? recorder.recordPostImage(absPath, gatedCtx(ctx), contentIfInMemory)
+				: noop(),
 		revertToolCall: (...args) => recorder.revertToolCall(...args),
-		beginShellCapture: (...args) =>
-			gate.live ? recorder.beginShellCapture(...args) : noop(),
-		endShellCapture: (...args) =>
-			gate.live ? recorder.endShellCapture(...args) : noop(),
+		beginShellCapture: (cwd, ctx) =>
+			gate.live ? recorder.beginShellCapture(cwd, gatedCtx(ctx)) : noop(),
+		endShellCapture: (ctx) =>
+			gate.live ? recorder.endShellCapture(gatedCtx(ctx)) : noop(),
 		captureWarning: () => (gate.live ? recorder.captureWarning() : null),
 		scopedToTurn: (turnId) =>
 			gatedRecorder(recorder.scopedToTurn(turnId), gate),
 	};
+}
+
+/** Raised for a `requireRevertible` capture requested after (or racing) revocation. */
+function revokedCaptureError(path: string): Error {
+	return new Error(
+		`Pre-image of ${resolve(path)} cannot be captured: the run's checkpoint ` +
+			"access was revoked when it moved to the background, so the write " +
+			"could not be rolled back; aborting before any modification",
+	);
 }
 
 export function scopeCheckpointRecorder(
@@ -265,9 +287,17 @@ export class CheckpointStore implements CheckpointRecorder {
 		const turnId = ctx.turnId ?? "detached";
 		const toolCallId = ctx.toolCallId ?? "unknown";
 		const tool = opts?.tool ?? "unknown";
-		this.ensureTurn(turnId);
+		// Re-checked after each await: an in-flight capture must not commit
+		// after revocation.
+		const revokedMidCapture = (): boolean => {
+			if (ctx.mayJournal?.() !== false) return false;
+			if (opts?.requireRevertible) throw revokedCaptureError(path);
+			return true;
+		};
 
 		const stats = await lstatOrNull(path);
+		if (revokedMidCapture()) return;
+		this.ensureTurn(turnId);
 		if (!stats) {
 			this.append({
 				type: "pre",
@@ -309,6 +339,7 @@ export class CheckpointStore implements CheckpointRecorder {
 		} else {
 			const content = await readFile(path);
 			const hash = await this.blobs.put(content);
+			if (revokedMidCapture()) return;
 			this.append({
 				type: "pre",
 				turnId,
@@ -338,7 +369,6 @@ export class CheckpointStore implements CheckpointRecorder {
 	): Promise<void> {
 		const path = resolve(absPath);
 		const turnId = ctx.turnId ?? "detached";
-		this.ensureTurn(turnId);
 
 		let postHash: string | null;
 		if (contentIfInMemory) {
@@ -347,6 +377,8 @@ export class CheckpointStore implements CheckpointRecorder {
 			const stats = await lstatOrNull(path);
 			postHash = stats?.isFile() ? sha256Hex(await readFile(path)) : null;
 		}
+		if (ctx.mayJournal?.() === false) return;
+		this.ensureTurn(turnId);
 		this.append({
 			type: "post",
 			turnId,
@@ -482,6 +514,8 @@ export class CheckpointStore implements CheckpointRecorder {
 				return;
 			}
 			this.shellLastStored = { snapshot: after, at: performance.now() };
+			// Revoked mid-walk: keep the refreshed baseline, journal nothing.
+			if (ctx.mayJournal?.() === false) return;
 			const diff = this.shellIndex.diff(before, after);
 			const changes = [...diff.created, ...diff.modified, ...diff.deleted];
 			if (changes.length === 0) return;

--- a/src/core/checkpoints/CheckpointStore.ts
+++ b/src/core/checkpoints/CheckpointStore.ts
@@ -208,8 +208,10 @@ export class CheckpointStore implements CheckpointRecorder {
 	private readonly turnIndex = new Map<string, TurnJournalRecord>();
 	/** turnIds with a finalize record; kept in step with `records`. */
 	private readonly finalizedTurns = new Set<string>();
-	/** turnIds that captured at least one pre/skip entry. */
-	private readonly turnsWithEntries = new Set<string>();
+	/** turnId -> count of its pre/skip entries that a revoke has not dropped. */
+	private readonly turnEntryCounts = new Map<string, number>();
+	/** `seq`s of pre/skip records neutralized by a `revoke` record. */
+	private readonly revokedSeqs = new Set<number>();
 	/** pathKey -> newest post record; kept in step with `records`. */
 	private readonly latestPostByPath = new Map<string, PostImageJournalRecord>();
 	private shellIndex: WorkspaceIndex | null = null;
@@ -298,8 +300,9 @@ export class CheckpointStore implements CheckpointRecorder {
 		const stats = await lstatOrNull(path);
 		if (revokedMidCapture()) return;
 		this.ensureTurn(turnId);
+		let entrySeq: number;
 		if (!stats) {
-			this.append({
+			entrySeq = this.append({
 				type: "pre",
 				turnId,
 				toolCallId,
@@ -311,7 +314,7 @@ export class CheckpointStore implements CheckpointRecorder {
 					: {}),
 			});
 		} else if (!stats.isFile()) {
-			this.append({
+			entrySeq = this.append({
 				type: "pre",
 				turnId,
 				toolCallId,
@@ -328,7 +331,7 @@ export class CheckpointStore implements CheckpointRecorder {
 						"not be rolled back; aborting before any modification",
 				);
 			}
-			this.append({
+			entrySeq = this.append({
 				type: "skip",
 				turnId,
 				toolCallId,
@@ -340,7 +343,7 @@ export class CheckpointStore implements CheckpointRecorder {
 			const content = await readFile(path);
 			const hash = await this.blobs.put(content);
 			if (revokedMidCapture()) return;
-			this.append({
+			entrySeq = this.append({
 				type: "pre",
 				turnId,
 				toolCallId,
@@ -355,6 +358,15 @@ export class CheckpointStore implements CheckpointRecorder {
 		// Write-ahead durability: the journal entry (and blob) must be on disk
 		// before the tool mutates the file. Flush errors abort the tool call.
 		await this.journal.flush();
+		// Revocation can still land while that flush is in flight. The entry is
+		// already durable and its post-image will now be suppressed, so drop it
+		// with a compensating record rather than leave an orphan pre-image the
+		// turn's /undo would use to revert the background run's write.
+		if (ctx.mayJournal?.() === false) {
+			this.append({ type: "revoke", turnId, ref: entrySeq, path });
+			await this.journal.flush();
+			if (opts?.requireRevertible) throw revokedCaptureError(path);
+		}
 	}
 
 	/**
@@ -398,6 +410,7 @@ export class CheckpointStore implements CheckpointRecorder {
 		const byPath = new Map<string, PreImageJournalRecord>();
 		for (const record of this.records) {
 			if (record.type !== "pre" || record.toolCallId !== toolCallId) continue;
+			if (this.isRevoked(record)) continue;
 			const key = this.pathKey(record.path);
 			if (!byPath.has(key)) byPath.set(key, record);
 		}
@@ -642,6 +655,7 @@ export class CheckpointStore implements CheckpointRecorder {
 				record.type !== "post"
 			)
 				continue;
+			if (this.isRevoked(record)) continue;
 			const acc = byTurn.get(record.turnId);
 			if (!acc) continue;
 			const key = this.pathKey(record.path);
@@ -994,17 +1008,31 @@ export class CheckpointStore implements CheckpointRecorder {
 		} else if (record.type === "finalize") {
 			this.finalizedTurns.add(record.turnId);
 		} else if (record.type === "pre" || record.type === "skip") {
-			this.turnsWithEntries.add(record.turnId);
+			this.bumpTurnEntries(record.turnId, 1);
 		} else if (record.type === "post") {
 			this.latestPostByPath.set(this.pathKey(record.path), record);
+		} else if (record.type === "revoke") {
+			this.revokedSeqs.add(record.ref);
+			this.bumpTurnEntries(record.turnId, -1);
 		}
 	}
 
+	private bumpTurnEntries(turnId: string, delta: number): void {
+		const next = (this.turnEntryCounts.get(turnId) ?? 0) + delta;
+		this.turnEntryCounts.set(turnId, Math.max(0, next));
+	}
+
+	/** True if a `revoke` record dropped this pre/skip entry. */
+	private isRevoked(record: JournalRecord): boolean {
+		return this.revokedSeqs.has(record.seq);
+	}
+
+	/** Returns the `seq` stamped on the record, so it can be revoked later. */
 	private append<T extends JournalRecord["type"]>(
 		record: Omit<Extract<JournalRecord, { type: T }>, "seq" | "ts"> & {
 			type: T;
 		},
-	): void {
+	): number {
 		const full = {
 			...record,
 			seq: this.seq++,
@@ -1013,6 +1041,7 @@ export class CheckpointStore implements CheckpointRecorder {
 		this.records.push(full);
 		this.indexRecord(full);
 		this.journal.write(full);
+		return full.seq;
 	}
 
 	private ensureTurn(turnId: string): void {
@@ -1023,7 +1052,7 @@ export class CheckpointStore implements CheckpointRecorder {
 	private finalizeTurn(turnId: string, status: "ok" | "cancelled"): void {
 		if (!this.turnRecordFor(turnId)) return;
 		if (this.finalizedTurns.has(turnId)) return;
-		const hasEntries = this.turnsWithEntries.has(turnId);
+		const hasEntries = (this.turnEntryCounts.get(turnId) ?? 0) > 0;
 		this.append({
 			type: "finalize",
 			turnId,
@@ -1056,7 +1085,8 @@ export class CheckpointStore implements CheckpointRecorder {
 			(record) =>
 				record.seq > seq &&
 				((record.type === "pre" && record.tool !== REDO_TOOL) ||
-					record.type === "skip"),
+					record.type === "skip") &&
+				!this.isRevoked(record),
 		);
 	}
 
@@ -1074,6 +1104,7 @@ export class CheckpointStore implements CheckpointRecorder {
 		>();
 		for (const record of this.records) {
 			if (record.type !== "pre" && record.type !== "skip") continue;
+			if (this.isRevoked(record)) continue;
 			if (target.kind === "redo-point") {
 				if (record.turnId !== target.turnId) continue;
 			} else {

--- a/src/core/checkpoints/journalTypes.ts
+++ b/src/core/checkpoints/journalTypes.ts
@@ -68,6 +68,21 @@ export interface SkipJournalRecord extends JournalRecordBase {
 	size?: number;
 }
 
+/**
+ * Neutralizes an earlier `pre`/`skip` record. Written when a capture's run
+ * lost checkpoint access (moved to the background) after its own record was
+ * already durable: the matching post-image will never be journaled, so the
+ * orphaned pre-image must not stay in the turn's checkpoint or `/undo` would
+ * revert a write the background run went on to complete.
+ */
+export interface RevokeJournalRecord extends JournalRecordBase {
+	type: "revoke";
+	turnId: string;
+	/** `seq` of the record this one drops. */
+	ref: number;
+	path: string;
+}
+
 /** Closes a checkpoint group; only finalized, non-empty groups are listed. */
 export interface FinalizeJournalRecord extends JournalRecordBase {
 	type: "finalize";
@@ -109,6 +124,7 @@ export type JournalRecord =
 	| PreImageJournalRecord
 	| PostImageJournalRecord
 	| SkipJournalRecord
+	| RevokeJournalRecord
 	| FinalizeJournalRecord
 	| UndoStartJournalRecord
 	| UndoFileJournalRecord

--- a/src/core/permissions/PermissionEngine.ts
+++ b/src/core/permissions/PermissionEngine.ts
@@ -24,8 +24,9 @@ function normalizedPathRules(
  * Deny/ask rules sit above the bypass gate on purpose: no mode can skip them.
  *
  * Manual mode prompts for reads too, but only where a human can answer: a
- * sub-agent or headless run has no prompt, so an "ask" there is a hard denial.
- * Those keep the read-only shortcut instead of failing every Read and Grep.
+ * headless run has no prompt, so an "ask" there is a hard denial, and a
+ * foreground sub-agent escalates its asks to the parent's prompt instead.
+ * Both keep the read-only shortcut instead of failing every Read and Grep.
  */
 export function decidePermission(
 	tool: Tool,

--- a/src/core/permissions/resolveToolPermission.ts
+++ b/src/core/permissions/resolveToolPermission.ts
@@ -79,14 +79,13 @@ export async function resolveToolPermission(
 	}
 
 	// behavior === "ask"
-	if (!pctx.interactive) {
-		return {
-			allowed: false,
-			denialReason: `Permission required for ${tool.displayName} — permission prompts are unavailable in this context.`,
-		};
-	}
+	const unavailable: GateResult = {
+		allowed: false,
+		denialReason: `Permission required for ${tool.displayName} — permission prompts are unavailable in this context.`,
+	};
+	if (!pctx.interactive && !pctx.escalate?.()) return unavailable;
 
-	return await withPromptLock(pctx, ctx.signal, async () => {
+	return await withPromptLock(pctx.promptHost ?? pctx, ctx.signal, async () => {
 		// Another prompt may have persisted an allow rule while this call waited.
 		// Re-evaluate so a parallel batch does not prompt redundantly.
 		decision = decidePermission(tool, input, pctx, ctx.cwd);
@@ -105,6 +104,8 @@ export async function resolveToolPermission(
 			input as Parameters<typeof tool.permissionHint>[0],
 		);
 		const question = hint ? `${base} ${hint}` : base;
+		const prompt = pctx.interactive ? ctx.askUser : pctx.escalate?.();
+		if (!prompt) return unavailable;
 		throwIfAborted(ctx.signal);
 		// Compute the rule up front so the "always" option can disclose its scope.
 		const raw = suggestRule(
@@ -114,12 +115,7 @@ export async function resolveToolPermission(
 				input as Parameters<typeof tool.permissionContentIsPaths>[0],
 			),
 		);
-		const answer = await promptForPermission(
-			question,
-			raw,
-			ctx.askUser,
-			ctx.signal,
-		);
+		const answer = await promptForPermission(question, raw, prompt, ctx.signal);
 
 		if (answer === "deny") {
 			return {

--- a/src/core/permissions/resolveToolPermission.ts
+++ b/src/core/permissions/resolveToolPermission.ts
@@ -115,7 +115,13 @@ export async function resolveToolPermission(
 				input as Parameters<typeof tool.permissionContentIsPaths>[0],
 			),
 		);
-		const answer = await promptForPermission(question, raw, prompt, ctx.signal);
+		let answer: "once" | "always" | "deny";
+		try {
+			answer = await promptForPermission(question, raw, prompt, ctx.signal);
+		} catch (error) {
+			if (!pctx.interactive && !pctx.escalate?.()) return unavailable;
+			throw error;
+		}
 		if (!pctx.interactive && !pctx.escalate?.()) return unavailable;
 
 		if (answer === "deny") {

--- a/src/core/permissions/resolveToolPermission.ts
+++ b/src/core/permissions/resolveToolPermission.ts
@@ -116,6 +116,7 @@ export async function resolveToolPermission(
 			),
 		);
 		const answer = await promptForPermission(question, raw, prompt, ctx.signal);
+		if (!pctx.interactive && !pctx.escalate?.()) return unavailable;
 
 		if (answer === "deny") {
 			return {

--- a/src/core/permissions/types.ts
+++ b/src/core/permissions/types.ts
@@ -1,3 +1,4 @@
+import type { AskUserFn } from "../tools/ToolContext.ts";
 import type { PermissionMode } from "./PermissionMode.ts";
 import type { RuleSet } from "./PermissionRules.ts";
 
@@ -24,6 +25,8 @@ export interface PermissionCheckContext {
 export interface PermissionContext {
 	mode: PermissionMode;
 	rules: RuleSet;
-	/** False in headless mode and sub-agents: an `ask` auto-denies. */
+	/** False in headless mode and sub-agents: an `ask` auto-denies unless `escalate` yields a prompt. */
 	interactive: boolean;
+	escalate?: () => AskUserFn | null;
+	promptHost?: PermissionContext;
 }

--- a/src/core/tools/AgentToolOutput.ts
+++ b/src/core/tools/AgentToolOutput.ts
@@ -6,4 +6,6 @@ export interface AgentToolOutput {
 	status: string;
 	rounds: number;
 	tracePath?: string;
+	/** Set when the spawn was handed to the background supervisor. */
+	runId?: string;
 }

--- a/src/core/tools/AgentToolOutput.ts
+++ b/src/core/tools/AgentToolOutput.ts
@@ -1,11 +1,39 @@
 export type AgentMode = "worker" | "rlm";
 
+export interface SpawnedAgent {
+	agent: string;
+	status: string;
+	rounds: number;
+	runId?: string;
+	children?: SpawnedAgent[];
+}
+
 export interface AgentToolOutput {
 	mode: AgentMode;
+	agent?: string;
 	report: string;
 	status: string;
 	rounds: number;
 	tracePath?: string;
-	/** Set when the spawn was handed to the background supervisor. */
 	runId?: string;
+	logPath?: string;
+	children?: SpawnedAgent[];
+}
+
+export function formatSpawnTree(
+	children: readonly SpawnedAgent[],
+	indent = "  ",
+): string {
+	return children
+		.map((child) => {
+			const state =
+				child.status === "backgrounded"
+					? `still running in background${child.runId ? ` (${child.runId})` : ""}`
+					: `${child.status}, ${child.rounds} ${child.rounds === 1 ? "round" : "rounds"}`;
+			const nested = child.children?.length
+				? `\n${formatSpawnTree(child.children, `${indent}  `)}`
+				: "";
+			return `${indent}- ${child.agent} — ${state}${nested}`;
+		})
+		.join("\n");
 }

--- a/src/core/tools/AgentToolOutputGuard.ts
+++ b/src/core/tools/AgentToolOutputGuard.ts
@@ -10,7 +10,8 @@ export function requireAgentToolOutput(output: unknown): AgentToolOutput {
 		typeof data.report === "string" &&
 		typeof data.status === "string" &&
 		typeof data.rounds === "number" &&
-		(data.tracePath === undefined || typeof data.tracePath === "string")
+		(data.tracePath === undefined || typeof data.tracePath === "string") &&
+		(data.runId === undefined || typeof data.runId === "string")
 	) {
 		return {
 			mode: data.mode,
@@ -18,6 +19,7 @@ export function requireAgentToolOutput(output: unknown): AgentToolOutput {
 			status: data.status,
 			rounds: data.rounds,
 			...(data.tracePath ? { tracePath: data.tracePath } : {}),
+			...(data.runId ? { runId: data.runId } : {}),
 		};
 	}
 	throw new Error("Agent tool returned invalid output");

--- a/src/core/tools/AgentToolOutputGuard.ts
+++ b/src/core/tools/AgentToolOutputGuard.ts
@@ -11,7 +11,10 @@ export function requireAgentToolOutput(output: unknown): AgentToolOutput {
 		typeof data.status === "string" &&
 		typeof data.rounds === "number" &&
 		(data.tracePath === undefined || typeof data.tracePath === "string") &&
-		(data.runId === undefined || typeof data.runId === "string")
+		(data.runId === undefined || typeof data.runId === "string") &&
+		(data.logPath === undefined || typeof data.logPath === "string") &&
+		(data.agent === undefined || typeof data.agent === "string") &&
+		(data.children === undefined || Array.isArray(data.children))
 	) {
 		return {
 			mode: data.mode,
@@ -20,6 +23,9 @@ export function requireAgentToolOutput(output: unknown): AgentToolOutput {
 			rounds: data.rounds,
 			...(data.tracePath ? { tracePath: data.tracePath } : {}),
 			...(data.runId ? { runId: data.runId } : {}),
+			...(data.logPath ? { logPath: data.logPath } : {}),
+			...(data.agent ? { agent: data.agent } : {}),
+			...(data.children?.length ? { children: data.children } : {}),
 		};
 	}
 	throw new Error("Agent tool returned invalid output");

--- a/src/core/tools/Tool.ts
+++ b/src/core/tools/Tool.ts
@@ -5,6 +5,7 @@ import type {
 	PermissionCheckContext,
 	PermissionDecision,
 } from "../permissions/types.ts";
+import type { AgentMode } from "./AgentToolOutput.ts";
 import { toAgentToolName } from "./names.ts";
 import { type OpenAITool, toOpenAITool } from "./schema.ts";
 import type { ToolContext } from "./ToolContext.ts";
@@ -106,6 +107,10 @@ export abstract class Tool<I = unknown, O = unknown> {
 	 * the caller, so return the raw human-readable summary.
 	 */
 	summarizeInput(_input: I): string | undefined {
+		return undefined;
+	}
+
+	agentModeForInput(_input: I): AgentMode | undefined {
 		return undefined;
 	}
 

--- a/src/core/tools/ToolContext.ts
+++ b/src/core/tools/ToolContext.ts
@@ -19,6 +19,16 @@ export type AskQuestionsFn = (
 	questions: AskUserQuestionSpec[],
 ) => Promise<string[]>;
 
+/**
+ * Whether a foreground turn is still waiting on this chain. Read through a
+ * live object rather than copied as a boolean: a run can be moved to the
+ * background long after every tool round has spread its own copy of the
+ * context, and budgets below it stop being enforced from that moment on.
+ */
+export interface BackgroundChainState {
+	readonly inBackground: boolean;
+}
+
 export interface ToolTraceContext {
 	forToolCall(toolCallId: string): ToolTraceContext;
 	createAgentTrace(input: {
@@ -49,7 +59,7 @@ export interface ToolContext {
 	getTodos?: () => readonly TodoItem[];
 	agentDepth?: number;
 	/** No foreground turn is waiting on this chain, so budgets below stop enforcing. */
-	inBackgroundChain?: boolean;
+	backgroundChain?: BackgroundChainState;
 	trace?: ToolTraceContext;
 	/** Optional language-server service for post-edit diagnostics. */
 	lsp?: LspService;

--- a/src/core/tools/ToolContext.ts
+++ b/src/core/tools/ToolContext.ts
@@ -48,6 +48,8 @@ export interface ToolContext {
 	askQuestions?: AskQuestionsFn;
 	getTodos?: () => readonly TodoItem[];
 	agentDepth?: number;
+	/** No foreground turn is waiting on this chain, so budgets below stop enforcing. */
+	inBackgroundChain?: boolean;
 	trace?: ToolTraceContext;
 	/** Optional language-server service for post-edit diagnostics. */
 	lsp?: LspService;

--- a/src/core/tools/ToolEventFactory.ts
+++ b/src/core/tools/ToolEventFactory.ts
@@ -12,7 +12,9 @@ export function toolStartEvent(
 	const inputSummary = summarizeToolInput(input, tool);
 	const name = tool?.displayName ?? ref.name;
 	const agentMode =
-		tool?.agentName === "agent" ? agentModeFromInput(input) : undefined;
+		tool?.agentName === "agent"
+			? (tool.agentModeForInput(input) ?? agentModeFromInput(input))
+			: undefined;
 	return {
 		type: "tool:start",
 		toolCallId: ref.id,

--- a/src/core/tools/ToolPolicy.ts
+++ b/src/core/tools/ToolPolicy.ts
@@ -17,9 +17,23 @@ export interface ToolPolicySnapshot {
 	computerUseEnabled: boolean;
 	browserUseEnabled: boolean;
 	skillDiscoveryEnabled: boolean;
+	/**
+	 * Expert mode, on the parent policy only. Implementation moves to the
+	 * expert model, so the parent loses the tools that would let it implement
+	 * inline and has to delegate through the Agent tool instead.
+	 */
+	expertModeEnabled?: boolean;
 }
 
 const SKILL_DISCOVERY_TOOLS = ["find_skill", "find_mcp"];
+
+/** Withheld from the parent while expert mode is on; sub-agents keep them. */
+export const EXPERT_EXECUTION_TOOLS: readonly string[] = [
+	"edit",
+	"write",
+	"apply_patch",
+	"execute",
+];
 
 export class ToolPolicy {
 	private readonly allowedTools: string[];
@@ -33,6 +47,7 @@ export class ToolPolicy {
 		this.excludedToolNames = combineToolExclusions(
 			snapshot.excludedTools,
 			snapshot.modelExcludedTools ?? [],
+			snapshot.expertModeEnabled ? EXPERT_EXECUTION_TOOLS : [],
 		);
 	}
 

--- a/src/core/tools/outputPreview.ts
+++ b/src/core/tools/outputPreview.ts
@@ -10,6 +10,11 @@ const DEFAULT_MAX_LINE_WIDTH = 200;
  */
 export const BROWSING_PREVIEW_LINES = 6;
 
+/** Sub-agent reports are the whole point of the call, so show more of them. */
+export const AGENT_REPORT_PREVIEW_LINES = 24;
+/** Kept near the transcript's render width so lines are cut once, not twice. */
+export const AGENT_REPORT_PREVIEW_WIDTH = 96;
+
 export interface OutputPreviewOptions {
 	/** Maximum number of content lines to keep before collapsing the rest. */
 	maxLines?: number;

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -389,7 +389,13 @@ async function main(): Promise<void> {
 	sweepStaleClipboardImages();
 	const flush = async (): Promise<void> => {
 		try {
+			// A run that finished between the UI exiting and this call is already
+			// out of the supervisor's map, so cancelAll cannot reach the report
+			// turn it started: close the notifier and cancel the controller too,
+			// then let dispose() wait for whatever turn is still unwinding.
+			backgroundSupervisor.disableNotifier();
 			backgroundSupervisor.cancelAll();
+			controller.cancel({ clearQueue: true });
 			await controller.dispose();
 			await lsp.shutdown();
 			await mcpManager.close();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -346,6 +346,7 @@ async function main(): Promise<void> {
 	// is still inspectable via /mcp; only the noisy startup emission is dropped.
 	const agentCatalog = await discoverAgents({ cwd: config.cwd });
 	const startupWarnings = [
+		...config.startupWarnings,
 		...hookConfig.warnings,
 		...permissionWarnings,
 		...agentCatalog.warnings,

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -9,6 +9,8 @@ import {
 import { Config } from "../config/Config.ts";
 import { parseFlags } from "../config/flags.ts";
 import { AgentController } from "../core/agent/AgentController.ts";
+import { BackgroundAgentSupervisor } from "../core/agent/BackgroundAgentSupervisor.ts";
+import { discoverAgents } from "../core/agents/discovery.ts";
 import { AttachmentManager } from "../core/attachments/AttachmentManager.ts";
 import { sweepStaleClipboardImages } from "../core/attachments/clipboardImage.ts";
 import {
@@ -256,6 +258,11 @@ async function main(): Promise<void> {
 		},
 	});
 	const skillController = new SkillController({ cwd: config.cwd, bus });
+	const backgroundSupervisor = new BackgroundAgentSupervisor(bus);
+	const agentCatalog = await discoverAgents({ cwd: config.cwd });
+	for (const warning of agentCatalog.warnings) {
+		bus.emit({ type: "system:warning", message: warning });
+	}
 	registry = new ToolRegistry(
 		createDefaultTools({
 			client,
@@ -265,6 +272,11 @@ async function main(): Promise<void> {
 			checkpoints,
 			getTools: () => registry.list(),
 			skillController,
+			getAgentCatalog: () => agentCatalog,
+			// Headless runs exit after one prompt, so a backgrounded agent would be
+			// cancelled before reporting — and the model would have been told a
+			// report was coming. Withhold the supervisor so those spawns run inline.
+			...(headless ? {} : { backgroundSupervisor }),
 			// Lazy: mcpController is declared below (it needs `registry`), resolved at call time.
 			getMcpRegistrar: () => mcpController,
 		}),
@@ -358,6 +370,7 @@ async function main(): Promise<void> {
 		hookController,
 		lsp,
 		checkpoints,
+		backgroundSupervisor,
 		getDurableSession: () => sessionLifecycle.current(),
 		onThreadReplaced: (threadId) => sessionLifecycle.replaceThread(threadId),
 		syncDynamicTools: syncMcpToolUpdates,
@@ -366,10 +379,20 @@ async function main(): Promise<void> {
 		getTranscriptPath: () =>
 			sessionPathsForRoot(sessionLifecycle.current().sessionRoot).clientLog,
 	});
+	// Deferred: the supervisor is built before the controller that consumes its
+	// reports. Reports queue at "later" so they never preempt user input.
+	backgroundSupervisor.setNotifier((report) => {
+		void controller.submit(report, {
+			emitUserMessage: false,
+			priority: "later",
+		});
+	});
+
 	const attachmentManager = new AttachmentManager();
 	sweepStaleClipboardImages();
 	const flush = async (): Promise<void> => {
 		try {
+			backgroundSupervisor.cancelAll();
 			await controller.dispose();
 			await lsp.shutdown();
 			await mcpManager.close();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -239,9 +239,11 @@ async function main(): Promise<void> {
 	// MCP init warnings (unset env vars, skipped/failed servers) are deliberately
 	// kept out of the startup surface — they cluttered every launch. Server status
 	// is still inspectable via /mcp; only the noisy startup emission is dropped.
+	const agentCatalog = await discoverAgents({ cwd: config.cwd });
 	const startupWarnings = [
 		...hookConfig.warnings,
 		...permissionWarnings,
+		...agentCatalog.warnings,
 		...renderWarnings,
 	];
 	for (const warning of startupWarnings) {
@@ -259,10 +261,6 @@ async function main(): Promise<void> {
 	});
 	const skillController = new SkillController({ cwd: config.cwd, bus });
 	const backgroundSupervisor = new BackgroundAgentSupervisor(bus);
-	const agentCatalog = await discoverAgents({ cwd: config.cwd });
-	for (const warning of agentCatalog.warnings) {
-		bus.emit({ type: "system:warning", message: warning });
-	}
 	registry = new ToolRegistry(
 		createDefaultTools({
 			client,
@@ -382,10 +380,13 @@ async function main(): Promise<void> {
 	// Deferred: the supervisor is built before the controller that consumes its
 	// reports. Reports queue at "later" so they never preempt user input.
 	backgroundSupervisor.setNotifier((report) => {
-		void controller.submit(report, {
-			emitUserMessage: false,
-			priority: "later",
-		});
+		void controller
+			.submit(report, {
+				emitUserMessage: false,
+				priority: "later",
+				displayContent: report,
+			})
+			.catch(() => {});
 	});
 
 	const attachmentManager = new AttachmentManager();

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -381,11 +381,7 @@ async function main(): Promise<void> {
 	// reports. Reports queue at "later" so they never preempt user input.
 	backgroundSupervisor.setNotifier((report) => {
 		void controller
-			.submit(report, {
-				emitUserMessage: false,
-				priority: "later",
-				displayContent: report,
-			})
+			.submit(report, { emitUserMessage: false, priority: "later" })
 			.catch(() => {});
 	});
 

--- a/src/prompts/profiles/_shared/system/build.tsx
+++ b/src/prompts/profiles/_shared/system/build.tsx
@@ -51,6 +51,7 @@ export function buildSystemPromptWith(
 		deps.getSystemPromptFragment(layout.base, promptContext),
 		options.computerUseEnabled ? deps.computer.prompt : "",
 		options.browserUseEnabled ? deps.browser.prompt : "",
+		options.expertModePrompt,
 		options.startupEnvironmentPrompt,
 		options.skillDiscoveryEnabled ? SKILL_DISCOVERY_GUIDANCE : "",
 		buildSkillCatalogPrompt(options.skillCatalog),

--- a/src/prompts/profiles/openai/tools/index.tsx
+++ b/src/prompts/profiles/openai/tools/index.tsx
@@ -368,7 +368,7 @@ Prompt requirements:
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| \`subagent_type\` | \`string enum: worker, rlm\` | no | worker uses tools; rlm analyzes structured inputs in a JavaScript REPL and must finish with SUBMIT(answer). |
+| \`subagent_type\` | \`string\` | no | Which agent to run; see "Available agents" below. Defaults to worker, which uses tools. An rlm agent instead analyzes structured inputs in a JavaScript REPL and must finish with SUBMIT(answer). |
 | \`prompt\` | \`string\` | yes | Complete delegated task. |
 | \`variables\` | \`object\` | no | Structured inputs for rlm sub-agents. |
 | \`timeout_ms\` | \`number\` | no | Wall-clock budget in milliseconds. |`.trim();

--- a/src/prompts/system/expertMode.tsx
+++ b/src/prompts/system/expertMode.tsx
@@ -1,0 +1,17 @@
+/**
+ * Explains the split the tool set already enforces: the parent has no edit,
+ * write, apply_patch, or execute tool while expert mode is on, so a model that
+ * reaches for one gets a hard failure. Saying so up front turns that into a
+ * plan-then-delegate turn instead of a wasted round.
+ */
+export function buildExpertModePrompt(executionModel: string): string {
+	return `## Expert mode
+
+Expert mode is on. You plan; \`${executionModel}\` implements.
+
+- You have no edit, write, apply_patch, or execute tool this turn. Every file change, command, migration, and test run happens inside a sub-agent — hand it over with \`agent\`.
+- Do the understanding yourself first: read, grep, and glob to find the files, read the code that matters, and decide what should change. That work is why you are on the stronger model.
+- Then delegate implementation. The sub-agent starts cold, so the prompt carries the whole job: exact paths, what to change in each, the conventions to follow, the commands to run, and how to verify. A vague hand-off is the main way expert mode produces bad work.
+- Split independent work across parallel sub-agents; keep work that shares a file in one.
+- Read the report that comes back and verify it against the code before telling the user it is done. If it is wrong, delegate the fix — do not narrate it as finished.`;
+}

--- a/src/prompts/system/types.ts
+++ b/src/prompts/system/types.ts
@@ -7,6 +7,8 @@ export interface SystemPromptOptions {
 	computerUseEnabled?: boolean;
 	browserUseEnabled?: boolean;
 	skillDiscoveryEnabled?: boolean;
+	/** Present only while expert mode is on; names the execution model. */
+	expertModePrompt?: string;
 	skillCatalog?: SkillCatalog;
 	activatedSkillsPrompt?: string;
 	hookContext?: string;

--- a/src/prompts/tools/agent.tsx
+++ b/src/prompts/tools/agent.tsx
@@ -24,5 +24,5 @@ function buildAgentPrompt(context: PromptContext = {}): string {
 Use it when a wide exploration would flood your context, when several independent investigations can run at the same time, or when a large input needs distilling to a few findings. Do not delegate work you can finish in a handful of calls, and do not use it to re-check your own work.${directLine}
 - The sub-agent starts with no memory of this conversation and cannot ask the user anything. Give it the goal, the relevant paths, commands, and constraints, whether it may edit files or must only investigate, and the exact shape of report you want back.
 - To run sub-agents in parallel, make several calls in one message. The user does not see the report; relay what they need.
-- subagent_type "worker" (default) uses the project tools. "rlm" analyzes the prompt and the \`variables\` object inside a JavaScript REPL and must finish by calling SUBMIT(answer); timeout_ms bounds how long it may run.`;
+- subagent_type picks which agent runs; see "Available agents". The default "worker" uses the project tools, while "rlm" analyzes the prompt and the \`variables\` object inside a JavaScript REPL and must finish by calling SUBMIT(answer); timeout_ms bounds how long it may run.`;
 }

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -1,6 +1,7 @@
 import type {
 	AgentChildToolCall,
 	AskUserRequest,
+	BackgroundRunSnapshot,
 	TodoItem,
 	UsageInfo,
 } from "../core/bus/events.ts";
@@ -86,6 +87,8 @@ export interface AppState {
 	pendingAsk: AskUserRequest | null;
 	model: string;
 	permissionMode: PermissionMode;
+	/** Sub-agents still running past the turn that spawned them. */
+	backgroundAgents: BackgroundRunSnapshot[];
 }
 
 export function initialState(
@@ -107,5 +110,6 @@ export function initialState(
 		pendingAsk: null,
 		model,
 		permissionMode,
+		backgroundAgents: [],
 	};
 }

--- a/src/state/Store.ts
+++ b/src/state/Store.ts
@@ -9,6 +9,11 @@ import {
 	genericInputSummary,
 } from "../core/tools/inputSummary.ts";
 import { toDisplayToolName } from "../core/tools/names.ts";
+import {
+	AGENT_REPORT_PREVIEW_LINES,
+	AGENT_REPORT_PREVIEW_WIDTH,
+	buildOutputPreview,
+} from "../core/tools/outputPreview.ts";
 import { shortId } from "../utils/id.ts";
 import { clampFlushLengthForOpenTable } from "../utils/markdownTable.ts";
 import type {
@@ -182,6 +187,20 @@ export function reduce(state: AppState, event: AgentEvent): AppState {
 			);
 			return tool?.kind === "tool" ? pushLive(next, tool) : next;
 		}
+
+		case "agent:background_started":
+			return {
+				...state,
+				backgroundAgents: [...state.backgroundAgents, event.run],
+			};
+
+		case "agent:background_finished":
+			return {
+				...state,
+				backgroundAgents: state.backgroundAgents.filter(
+					(run) => run.id !== event.run.id,
+				),
+			};
 
 		case "agent:child_tool_result": {
 			if (isToolCommittedTerminal(state, event.agentToolCallId)) return state;
@@ -448,10 +467,14 @@ function agentToolResultDetail(output: AgentToolOutput): string | undefined {
 	]
 		.filter(Boolean)
 		.join(", ");
-	const detail = `${meta}\n${output.report}`;
-	return detail.length > 4_000
-		? `${detail.slice(0, 4_000)}\n[truncated]`
-		: detail;
+	// The transcript renderer truncates each line to the terminal width, so cap
+	// line count and width here rather than emitting a raw slice that shreds
+	// wide markdown. The full report reaches the model and the trace file.
+	const preview = buildOutputPreview(output.report, {
+		maxLines: AGENT_REPORT_PREVIEW_LINES,
+		maxLineWidth: AGENT_REPORT_PREVIEW_WIDTH,
+	});
+	return preview ? `${meta}\n${preview}` : meta;
 }
 
 function push(state: AppState, item: TranscriptItem): AppState {

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -241,7 +241,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 	private async runRlm(run: AgentRun): Promise<ToolResult<AgentToolOutput>> {
 		const { input, ctx, definition, trace, tracePath } = run;
 		const result = await this.gated(run, () =>
-			this.deps.createRLMLoop().run({
+			this.deps.createRLMLoop(definition).run({
 				prompt: input.prompt,
 				signal: ctx.signal,
 				timeoutMs: input.timeout_ms ?? definition.timeoutMs,

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -280,7 +280,6 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 				: undefined;
 		// A background run's tool row and checkpoint are already committed.
 		const foreground = signal === ctx.signal;
-		const parentInBackground = ctx.inBackgroundChain === true;
 		const onDeadline = this.deadlineHandoff(run, foreground);
 
 		return this.deps.runner.run({
@@ -300,10 +299,10 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 				: {}),
 			parentPermissions: ctx.permissions,
 			trace: workerTrace,
-			parentInBackground,
 			// A run launched into the background, or already inside one, is the
 			// background chain from its children's point of view.
-			chainInBackground: !foreground || parentInBackground,
+			chainInBackground: !foreground,
+			...(ctx.backgroundChain ? { parentChain: ctx.backgroundChain } : {}),
 			...(onDeadline ? { onDeadline } : {}),
 		});
 	}

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -9,10 +9,7 @@ import type {
 import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
 import { WORKER_AGENT_NAME } from "../core/agents/builtin.ts";
 import type { PermissionDecision } from "../core/permissions/types.ts";
-import {
-	formatSpawnTree,
-	type SpawnedAgent,
-} from "../core/tools/AgentToolOutput.ts";
+import { formatSpawnTree } from "../core/tools/AgentToolOutput.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
@@ -80,7 +77,7 @@ const schema = z.object({
 		.positive()
 		.optional()
 		.describe(
-			"Optional wall-clock budget for rlm sub-agents. When the budget expires, the RLM returns a partial-progress report instead of continuing normal code execution.",
+			"Optional wall-clock budget for this run. On expiry a worker moves to the background and keeps going; an rlm returns a partial-progress report.",
 		),
 });
 

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -9,7 +9,10 @@ import type {
 import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
 import { WORKER_AGENT_NAME } from "../core/agents/builtin.ts";
 import type { PermissionDecision } from "../core/permissions/types.ts";
-import { formatSpawnTree } from "../core/tools/AgentToolOutput.ts";
+import {
+	type AgentMode,
+	formatSpawnTree,
+} from "../core/tools/AgentToolOutput.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
@@ -143,6 +146,14 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 
 	override isConcurrencySafe(_input: AgentToolInput): boolean {
 		return true;
+	}
+
+	override agentModeForInput(input: AgentToolInput): AgentMode | undefined {
+		const requested =
+			input && typeof input === "object" ? input.subagent_type : undefined;
+		return this.deps
+			.getCatalog()
+			.get(typeof requested === "string" ? requested : WORKER_AGENT_NAME)?.mode;
 	}
 
 	// Spawning is orchestration, not a direct effect: the sub-agent inherits the

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -438,7 +438,7 @@ function agentToolParameters(agentNames: string[]): Record<string, unknown> {
 				type: "integer",
 				minimum: 1,
 				description:
-					"Optional wall-clock budget in milliseconds for RLM sub-agents.",
+					"Optional wall-clock budget in milliseconds. On expiry a worker moves to the background and keeps going; an rlm returns partial progress.",
 			},
 		},
 		required: ["prompt"],

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -309,6 +309,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 					}
 				: {}),
 			parentPermissions: ctx.permissions,
+			parentAskUser: ctx.askUser,
 			trace: workerTrace,
 			// A run launched into the background, or already inside one, is the
 			// background chain from its children's point of view.

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -120,12 +120,6 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 
 	constructor(private readonly deps: AgentToolDeps) {
 		super();
-		// A chain holds one permit per level, so fewer permits than levels deadlocks.
-		if (deps.maxConcurrent < deps.maxDepth) {
-			throw new Error(
-				`AgentTool requires maxConcurrent (${deps.maxConcurrent}) >= maxDepth (${deps.maxDepth}) to avoid deadlocking nested spawns.`,
-			);
-		}
 		this.slots = new Semaphore(deps.maxConcurrent);
 	}
 
@@ -247,14 +241,9 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		);
 	}
 
-	private async runRlm({
-		input,
-		ctx,
-		definition,
-		trace,
-		tracePath,
-	}: AgentRun): Promise<ToolResult<AgentToolOutput>> {
-		const result = await this.slots.run(() =>
+	private async runRlm(run: AgentRun): Promise<ToolResult<AgentToolOutput>> {
+		const { input, ctx, definition, trace, tracePath } = run;
+		const result = await this.gated(run, () =>
 			this.deps.createRLMLoop().run({
 				prompt: input.prompt,
 				signal: ctx.signal,
@@ -303,6 +292,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 			depth,
 			parentCwd: ctx.cwd,
 			parentSignal: signal,
+			...(input.timeout_ms ? { timeoutMs: input.timeout_ms } : {}),
 			...(foreground
 				? {
 						parentBus: ctx.bus,
@@ -339,9 +329,19 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		});
 	}
 
+	/**
+	 * Only top-level spawns take a permit. A permit holder must never wait on
+	 * another permit: N parallel chains would each hold one and block forever on
+	 * their descendants. Depth is capped, so the tree stays bounded regardless.
+	 */
+	private gated<T>(run: AgentRun, fn: () => Promise<T>): Promise<T> {
+		if (run.depth > 1) return fn();
+		return this.slots.run(fn, run.ctx.signal);
+	}
+
 	private async runWorker(run: AgentRun): Promise<ToolResult<AgentToolOutput>> {
 		const { ctx, tracePath } = run;
-		const result: SubAgentResult = await this.slots.run(() =>
+		const result: SubAgentResult = await this.gated(run, () =>
 			this.runWorkerAgainst(run, ctx.signal),
 		);
 

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -1,6 +1,10 @@
 import { z } from "zod";
+import type { AgentTraceStore } from "../core/agent/AgentTraceStore.ts";
+import type { BackgroundAgentSupervisor } from "../core/agent/BackgroundAgentSupervisor.ts";
 import type { JSONValue } from "../core/agent/rlm/RLMTypes.ts";
 import type { SubAgentResult } from "../core/agent/SubAgentRunner.ts";
+import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
+import { WORKER_AGENT_NAME } from "../core/agents/builtin.ts";
 import type { PermissionDecision } from "../core/permissions/types.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
@@ -8,6 +12,7 @@ import type { ToolContext } from "../core/tools/ToolContext.ts";
 import { ok, type ToolResult } from "../core/tools/ToolResult.ts";
 import type { PromptContext } from "../prompts/PromptModule.ts";
 import { getToolPrompt } from "../prompts/tools/index.tsx";
+import { Semaphore } from "../utils/semaphore.ts";
 import { pluralize } from "../utils/string.ts";
 import type {
 	AgentToolDeps,
@@ -45,10 +50,10 @@ const jsonValueSchema = z.custom<JSONValue>((value) => {
 
 const schema = z.object({
 	subagent_type: z
-		.enum(["worker", "rlm"])
+		.string()
 		.optional()
 		.describe(
-			'"worker" (default) runs a tool-using sub-agent over the project; "rlm" analyzes the prompt and provided variables in a JavaScript REPL.',
+			'Name of the agent to run. Defaults to "worker". Validated against the agent catalog at call time.',
 		),
 	prompt: z
 		.string()
@@ -78,6 +83,16 @@ export type {
 	AgentToolOutput,
 } from "./AgentToolTypes.ts";
 
+/** One resolved spawn, shared by the worker and rlm execution paths. */
+interface AgentRun {
+	input: AgentToolInput;
+	ctx: ToolContext;
+	definition: AgentDefinition;
+	depth: number;
+	trace: AgentTraceStore | null;
+	tracePath: string | undefined;
+}
+
 /**
  * Spawns an isolated sub-agent (a recursive worker). The parent receives only
  * the sub-agent's distilled report, never its intermediate tool churn, which
@@ -88,16 +103,31 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 	readonly inputSchema = schema;
 	readonly readOnly = false;
 
+	// Shared across depths: toolFactory hands children this same instance, so
+	// nested spawns draw from one pool rather than one per level.
+	private readonly slots: Semaphore;
+
 	override get displayName(): string {
 		return "Subagent";
 	}
 
 	constructor(private readonly deps: AgentToolDeps) {
 		super();
+		// A spawn chain holds one permit per level while each ancestor awaits its
+		// descendant, so fewer permits than levels lets a chain deadlock against
+		// itself. Fail at construction rather than at an unlucky nesting depth.
+		if (deps.maxConcurrent < deps.maxDepth) {
+			throw new Error(
+				`AgentTool requires maxConcurrent (${deps.maxConcurrent}) >= maxDepth (${deps.maxDepth}) to avoid deadlocking nested spawns.`,
+			);
+		}
+		this.slots = new Semaphore(deps.maxConcurrent);
 	}
 
 	override prompt(context: PromptContext = {}): string {
-		return getToolPrompt(this.name, context);
+		const base = getToolPrompt(this.name, context);
+		const catalog = this.deps.getCatalog().promptCatalog;
+		return catalog ? `${base}\n\n### Available agents\n\n${catalog}` : base;
 	}
 
 	override toJSONSchema(context: PromptContext = {}): OpenAITool {
@@ -106,7 +136,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 			function: {
 				name: this.agentName,
 				description: this.prompt(context),
-				parameters: agentToolParameters(),
+				parameters: agentToolParameters(this.deps.getCatalog().names),
 			},
 		};
 	}
@@ -133,12 +163,20 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		input: AgentToolInput,
 		ctx: ToolContext,
 	): Promise<ToolResult<AgentToolOutput>> {
-		const subagentType = input.subagent_type ?? "worker";
+		const catalog = this.deps.getCatalog();
+		const requested = input.subagent_type ?? WORKER_AGENT_NAME;
+		const definition = catalog.get(requested);
+		if (!definition) {
+			throw new Error(
+				`Unknown subagent_type '${requested}'. Available agents: ${catalog.names.join(", ")}.`,
+			);
+		}
+
 		const depth = (ctx.agentDepth ?? 0) + 1;
 		const traceContext = ctx.trace;
 		const trace =
 			(await traceContext?.createAgentTrace({
-				mode: subagentType,
+				mode: definition.mode,
 				prompt: input.prompt,
 			})) ?? null;
 		const tracePath = trace ? trace.relativePath(trace.paths.root) : undefined;
@@ -148,7 +186,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 				"Agent recursion depth limit reached. Complete this work directly instead of spawning another sub-agent.";
 			return ok(
 				{
-					mode: subagentType,
+					mode: definition.mode,
 					report,
 					status: "rejected",
 					rounds: 0,
@@ -159,33 +197,91 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 			);
 		}
 
-		if (subagentType === "rlm") {
-			try {
-				const result = await this.deps.createRLMLoop().run({
-					prompt: input.prompt,
-					signal: ctx.signal,
-					timeoutMs: input.timeout_ms,
-					variables: input.variables,
-				});
-				await trace?.writeRLMResult(result);
-				return ok(
-					{
-						mode: "rlm",
-						report: result.report,
-						status: result.status,
-						rounds: result.rounds,
-						...(tracePath ? { tracePath } : {}),
-					},
-					result.report,
-					agentTitle(result.status, result.rounds),
-				);
-			} catch (err) {
-				await trace?.writeError(err);
-				throw err;
+		const run: AgentRun = { input, ctx, definition, depth, trace, tracePath };
+		try {
+			// Background dispatch is top-level only. A nested background spawn
+			// would outlive the sub-agent that owns it, leaving no one to receive
+			// its report, so deeper spawns run inline regardless of the flag.
+			if (
+				definition.background &&
+				this.deps.supervisor &&
+				definition.mode === "worker" &&
+				depth === 1
+			) {
+				return this.launchBackground(run, this.deps.supervisor);
 			}
+			return definition.mode === "rlm"
+				? await this.runRlm(run)
+				: await this.runWorker(run);
+		} catch (err) {
+			await trace?.writeError(err);
+			throw err;
 		}
+	}
 
-		let result: SubAgentResult;
+	private launchBackground(
+		run: AgentRun,
+		supervisor: BackgroundAgentSupervisor,
+	): ToolResult<AgentToolOutput> {
+		const snapshot = supervisor.launch({
+			definition: run.definition,
+			prompt: run.input.prompt,
+			run: (signal) => this.runWorkerAgainst(run, signal),
+		});
+		const report = `Launched background agent "${run.definition.name}" (${snapshot.id}). You will be given its report when it finishes. Continue with other work; do not wait for it, and do not duplicate what it is doing.`;
+		return ok(
+			{
+				mode: "worker",
+				report,
+				status: "launched",
+				rounds: 0,
+				runId: snapshot.id,
+				...(run.tracePath ? { tracePath: run.tracePath } : {}),
+			},
+			report,
+			`Running in background (${snapshot.id})`,
+		);
+	}
+
+	private async runRlm({
+		input,
+		ctx,
+		definition,
+		trace,
+		tracePath,
+	}: AgentRun): Promise<ToolResult<AgentToolOutput>> {
+		const result = await this.slots.run(() =>
+			this.deps.createRLMLoop().run({
+				prompt: input.prompt,
+				signal: ctx.signal,
+				timeoutMs: input.timeout_ms ?? definition.timeoutMs,
+				variables: input.variables,
+			}),
+		);
+		await trace?.writeRLMResult(result);
+		return ok(
+			{
+				mode: "rlm",
+				report: result.report,
+				status: result.status,
+				rounds: result.rounds,
+				...(tracePath ? { tracePath } : {}),
+			},
+			result.report,
+			agentTitle(result.status, result.rounds),
+		);
+	}
+
+	/**
+	 * Runs the sub-agent under an explicit signal. Foreground calls pass the
+	 * turn's signal; background calls pass the supervisor's, which is unlinked
+	 * from the turn so cancelling the foreground leaves them running.
+	 */
+	private runWorkerAgainst(
+		{ input, ctx, definition, depth, trace }: AgentRun,
+		signal: AbortSignal,
+	): Promise<SubAgentResult> {
+		const traceContext = ctx.trace;
 		const workerTrace =
 			trace && traceContext
 				? {
@@ -194,23 +290,36 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 						clientLogPath: trace.paths.clientLog,
 					}
 				: undefined;
-		try {
-			result = await this.deps.runner.run({
-				prompt: input.prompt,
-				depth,
-				parentCwd: ctx.cwd,
-				parentSignal: ctx.signal,
-				parentBus: ctx.bus,
-				parentToolCallId: ctx.toolCallId,
-				parentTurnId: ctx.turnId,
-				checkpoints: ctx.checkpoints,
-				parentPermissions: ctx.permissions,
-				trace: workerTrace,
-			});
-		} catch (err) {
-			await trace?.writeError(err);
-			throw err;
-		}
+		// A background run outlives the spawning turn, so its tool row is already
+		// closed and its turn's checkpoint already finalized: relaying progress or
+		// journaling edits there would mutate committed state. Both are dropped.
+		const foreground = signal === ctx.signal;
+
+		return this.deps.runner.run({
+			prompt: input.prompt,
+			definition,
+			depth,
+			parentCwd: ctx.cwd,
+			parentSignal: signal,
+			...(foreground
+				? {
+						parentBus: ctx.bus,
+						parentToolCallId: ctx.toolCallId,
+						parentTurnId: ctx.turnId,
+						checkpoints: ctx.checkpoints,
+					}
+				: {}),
+			parentPermissions: ctx.permissions,
+			trace: workerTrace,
+		});
+	}
+
+	private async runWorker(run: AgentRun): Promise<ToolResult<AgentToolOutput>> {
+		const { ctx, tracePath } = run;
+		const result: SubAgentResult = await this.slots.run(() =>
+			this.runWorkerAgainst(run, ctx.signal),
+		);
+
 		return ok(
 			{
 				mode: "worker",
@@ -226,17 +335,23 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 }
 
 function agentTitle(status: string, rounds: number): string {
-	return status === "completed"
-		? `Completed in ${rounds} ${pluralize(rounds, "round")}`
-		: `Failed after ${rounds} ${pluralize(rounds, "round")}`;
+	const suffix = `${rounds} ${pluralize(rounds, "round")}`;
+	if (status === "completed") return `Completed in ${suffix}`;
+	if (status === "timed_out") return `Timed out after ${suffix}`;
+	return `Failed after ${suffix}`;
 }
 
 function workerReportForLLM(result: SubAgentResult): string {
 	if (result.status === "completed") return result.report;
+	// A timed-out worker still summarized what it found, so hand the parent the
+	// partial report rather than an error string it can only give up on.
+	if (result.status === "timed_out") {
+		return `Agent worker timed out after ${result.toolRounds} rounds. Partial progress:\n\n${result.report}`;
+	}
 	return `Error: Agent worker ${result.status} after ${result.toolRounds} rounds: ${result.report}`;
 }
 
-function agentToolParameters(): Record<string, unknown> {
+function agentToolParameters(agentNames: string[]): Record<string, unknown> {
 	const jsonValueParameterSchema = {
 		anyOf: [
 			{ type: "string" },
@@ -256,8 +371,8 @@ function agentToolParameters(): Record<string, unknown> {
 		properties: {
 			subagent_type: {
 				type: "string",
-				enum: ["worker", "rlm"],
-				description: '"worker" (default) or "rlm".',
+				...(agentNames.length > 0 ? { enum: agentNames } : {}),
+				description: `Agent to run. Defaults to "${WORKER_AGENT_NAME}".`,
 			},
 			prompt: {
 				type: "string",

--- a/src/tools/AgentTool.tsx
+++ b/src/tools/AgentTool.tsx
@@ -2,10 +2,17 @@ import { z } from "zod";
 import type { AgentTraceStore } from "../core/agent/AgentTraceStore.ts";
 import type { BackgroundAgentSupervisor } from "../core/agent/BackgroundAgentSupervisor.ts";
 import type { JSONValue } from "../core/agent/rlm/RLMTypes.ts";
-import type { SubAgentResult } from "../core/agent/SubAgentRunner.ts";
+import type {
+	DeadlineHandoff,
+	SubAgentResult,
+} from "../core/agent/SubAgentRunner.ts";
 import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
 import { WORKER_AGENT_NAME } from "../core/agents/builtin.ts";
 import type { PermissionDecision } from "../core/permissions/types.ts";
+import {
+	formatSpawnTree,
+	type SpawnedAgent,
+} from "../core/tools/AgentToolOutput.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
@@ -113,9 +120,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 
 	constructor(private readonly deps: AgentToolDeps) {
 		super();
-		// A spawn chain holds one permit per level while each ancestor awaits its
-		// descendant, so fewer permits than levels lets a chain deadlock against
-		// itself. Fail at construction rather than at an unlucky nesting depth.
+		// A chain holds one permit per level, so fewer permits than levels deadlocks.
 		if (deps.maxConcurrent < deps.maxDepth) {
 			throw new Error(
 				`AgentTool requires maxConcurrent (${deps.maxConcurrent}) >= maxDepth (${deps.maxDepth}) to avoid deadlocking nested spawns.`,
@@ -199,9 +204,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 
 		const run: AgentRun = { input, ctx, definition, depth, trace, tracePath };
 		try {
-			// Background dispatch is top-level only. A nested background spawn
-			// would outlive the sub-agent that owns it, leaving no one to receive
-			// its report, so deeper spawns run inline regardless of the flag.
+			// Top-level only: a nested background spawn would outlive its owner.
 			if (
 				definition.background &&
 				this.deps.supervisor &&
@@ -232,6 +235,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		return ok(
 			{
 				mode: "worker",
+				agent: run.definition.name,
 				report,
 				status: "launched",
 				rounds: 0,
@@ -262,6 +266,7 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		return ok(
 			{
 				mode: "rlm",
+				agent: definition.name,
 				report: result.report,
 				status: result.status,
 				rounds: result.rounds,
@@ -272,15 +277,12 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		);
 	}
 
-	/**
-	 * Runs the sub-agent under an explicit signal. Foreground calls pass the
-	 * turn's signal; background calls pass the supervisor's, which is unlinked
-	 * from the turn so cancelling the foreground leaves them running.
-	 */
+	/** Foreground calls pass the turn's signal; background calls the supervisor's. */
 	private runWorkerAgainst(
-		{ input, ctx, definition, depth, trace }: AgentRun,
+		run: AgentRun,
 		signal: AbortSignal,
 	): Promise<SubAgentResult> {
+		const { input, ctx, definition, depth, trace } = run;
 		const traceContext = ctx.trace;
 		const workerTrace =
 			trace && traceContext
@@ -290,10 +292,10 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 						clientLogPath: trace.paths.clientLog,
 					}
 				: undefined;
-		// A background run outlives the spawning turn, so its tool row is already
-		// closed and its turn's checkpoint already finalized: relaying progress or
-		// journaling edits there would mutate committed state. Both are dropped.
+		// A background run's tool row and checkpoint are already committed.
 		const foreground = signal === ctx.signal;
+		const parentInBackground = ctx.inBackgroundChain === true;
+		const onDeadline = this.deadlineHandoff(run, foreground);
 
 		return this.deps.runner.run({
 			prompt: input.prompt,
@@ -311,6 +313,29 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 				: {}),
 			parentPermissions: ctx.permissions,
 			trace: workerTrace,
+			parentInBackground,
+			// A run launched into the background, or already inside one, is the
+			// background chain from its children's point of view.
+			chainInBackground: !foreground || parentInBackground,
+			...(onDeadline ? { onDeadline } : {}),
+		});
+	}
+
+	/** Hands a slow run to the background instead of discarding its work. */
+	private deadlineHandoff(
+		run: AgentRun,
+		foreground: boolean,
+	): ((handoff: DeadlineHandoff) => { runId: string } | undefined) | undefined {
+		const supervisor = this.deps.supervisor;
+		// Only the top may hand off: a descendant would report past its owner.
+		if (!supervisor || !foreground || run.depth !== 1) return undefined;
+		return ({ continuation, cancel }) => ({
+			runId: supervisor.adopt({
+				definition: run.definition,
+				prompt: run.input.prompt,
+				continuation,
+				cancel,
+			}).id,
 		});
 	}
 
@@ -323,13 +348,19 @@ export class AgentTool extends Tool<AgentToolInput, AgentToolOutput> {
 		return ok(
 			{
 				mode: "worker",
+				agent: run.definition.name,
 				report: result.report,
 				status: result.status,
 				rounds: result.toolRounds,
 				...(tracePath ? { tracePath } : {}),
+				...(result.runId ? { runId: result.runId } : {}),
+				...(result.logPath ? { logPath: result.logPath } : {}),
+				...(result.children?.length ? { children: result.children } : {}),
 			},
 			workerReportForLLM(result),
-			agentTitle(result.status, result.toolRounds),
+			result.status === "backgrounded"
+				? `Still running in background (${result.runId})`
+				: agentTitle(result.status, result.toolRounds),
 		);
 	}
 }
@@ -341,8 +372,30 @@ function agentTitle(status: string, rounds: number): string {
 	return `Failed after ${suffix}`;
 }
 
+function withSpawnTree(text: string, result: SubAgentResult): string {
+	if (!result.children?.length) return text;
+	return `${text}
+
+Sub-agents it spawned:
+${formatSpawnTree(result.children)}`;
+}
+
 function workerReportForLLM(result: SubAgentResult): string {
+	return withSpawnTree(workerReportBody(result), result);
+}
+
+function workerReportBody(result: SubAgentResult): string {
 	if (result.status === "completed") return result.report;
+	// A handed-off run is still doing the work. Say so explicitly, or the model
+	// reads a non-completed status as failure and starts the task over.
+	if (result.status === "backgrounded") {
+		const log = result.logPath
+			? `\nIts transcript so far is at ${result.logPath} — read that to see where it is.`
+			: "";
+		return `The sub-agent exceeded its time budget but is STILL RUNNING in the background (id: ${result.runId}). It has not failed and its work is not lost.${log}
+
+Do not start this task again. You will be given its report when it finishes. Continue with other work in the meantime, or tell the user it is still going.`;
+	}
 	// A timed-out worker still summarized what it found, so hand the parent the
 	// partial report rather than an error string it can only give up on.
 	if (result.status === "timed_out") {

--- a/src/tools/AgentToolConstants.ts
+++ b/src/tools/AgentToolConstants.ts
@@ -1,10 +1,6 @@
 export const DEFAULT_AGENT_MAX_DEPTH = 2;
 
-/**
- * Concurrent sub-agent runs across all depths; excess spawns queue. Must stay
- * >= DEFAULT_AGENT_MAX_DEPTH, since a nested chain holds one permit per level
- * (AgentTool enforces this).
- */
+/** Concurrent top-level sub-agent runs; excess spawns queue. */
 export const DEFAULT_AGENT_MAX_CONCURRENT = 8;
 
 export const NON_DELEGATABLE_AGENT_TOOLS: ReadonlySet<string> = new Set([

--- a/src/tools/AgentToolConstants.ts
+++ b/src/tools/AgentToolConstants.ts
@@ -1,5 +1,12 @@
 export const DEFAULT_AGENT_MAX_DEPTH = 2;
 
+/**
+ * Concurrent sub-agent runs across all depths; excess spawns queue. Must stay
+ * >= DEFAULT_AGENT_MAX_DEPTH, since a nested chain holds one permit per level
+ * (AgentTool enforces this).
+ */
+export const DEFAULT_AGENT_MAX_CONCURRENT = 8;
+
 export const NON_DELEGATABLE_AGENT_TOOLS: ReadonlySet<string> = new Set([
 	"ask_user",
 	"browser",

--- a/src/tools/AgentToolTypes.ts
+++ b/src/tools/AgentToolTypes.ts
@@ -4,6 +4,7 @@ import type { RLMLoop } from "../core/agent/rlm/RLMLoop.ts";
 import type { JSONObject } from "../core/agent/rlm/RLMTypes.ts";
 import type { SubAgentRunner } from "../core/agent/SubAgentRunner.ts";
 import type { AgentCatalog } from "../core/agents/AgentCatalog.ts";
+import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
 import type { CheckpointRecorder } from "../core/checkpoints/CheckpointStore.ts";
 import type { HookController } from "../core/hooks/index.ts";
 import type { LspService } from "../core/lsp/index.ts";
@@ -26,7 +27,7 @@ export interface AgentToolInput {
 
 export interface AgentToolDeps {
 	runner: Pick<SubAgentRunner, "run">;
-	createRLMLoop: () => Pick<RLMLoop, "run">;
+	createRLMLoop: (definition: AgentDefinition) => Pick<RLMLoop, "run">;
 	getCatalog: () => AgentCatalog;
 	maxDepth: number;
 	maxConcurrent: number;

--- a/src/tools/AgentToolTypes.ts
+++ b/src/tools/AgentToolTypes.ts
@@ -1,11 +1,12 @@
 import type { Config } from "../config/Config.ts";
+import type { BackgroundAgentSupervisor } from "../core/agent/BackgroundAgentSupervisor.ts";
 import type { RLMLoop } from "../core/agent/rlm/RLMLoop.ts";
 import type { JSONObject } from "../core/agent/rlm/RLMTypes.ts";
 import type { SubAgentRunner } from "../core/agent/SubAgentRunner.ts";
+import type { AgentCatalog } from "../core/agents/AgentCatalog.ts";
 import type { CheckpointRecorder } from "../core/checkpoints/CheckpointStore.ts";
 import type { HookController } from "../core/hooks/index.ts";
 import type { LspService } from "../core/lsp/index.ts";
-import type { AgentMode } from "../core/tools/AgentToolOutput.ts";
 import type { Tool } from "../core/tools/Tool.ts";
 import type { AgentClient } from "../providers/AgentClient.ts";
 import type { McpRegistrar } from "./FindMcpTool.tsx";
@@ -17,7 +18,7 @@ export type {
 } from "../core/tools/AgentToolOutput.ts";
 
 export interface AgentToolInput {
-	subagent_type?: AgentMode;
+	subagent_type?: string;
 	prompt: string;
 	variables?: JSONObject;
 	timeout_ms?: number;
@@ -26,7 +27,11 @@ export interface AgentToolInput {
 export interface AgentToolDeps {
 	runner: Pick<SubAgentRunner, "run">;
 	createRLMLoop: () => Pick<RLMLoop, "run">;
+	getCatalog: () => AgentCatalog;
 	maxDepth: number;
+	maxConcurrent: number;
+	/** Absent in tests and non-interactive runs; background spawns then run inline. */
+	supervisor?: BackgroundAgentSupervisor;
 }
 
 export interface DefaultToolDeps {
@@ -38,4 +43,6 @@ export interface DefaultToolDeps {
 	skillController?: SkillActivator;
 	getMcpRegistrar?: () => McpRegistrar | undefined;
 	checkpoints?: CheckpointRecorder;
+	getAgentCatalog?: () => AgentCatalog;
+	backgroundSupervisor?: BackgroundAgentSupervisor;
 }

--- a/src/tools/delegatableTools.ts
+++ b/src/tools/delegatableTools.ts
@@ -1,0 +1,53 @@
+import type { AgentDefinition } from "../core/agents/AgentDefinition.ts";
+import { canonicalToolName } from "../core/tools/names.ts";
+import type { Tool } from "../core/tools/Tool.ts";
+import { NON_DELEGATABLE_AGENT_TOOLS } from "./AgentToolConstants.ts";
+
+export interface SelectDelegatableToolsOptions {
+	definition: AgentDefinition;
+	/** Tools already narrowed by the session's ToolPolicy. */
+	candidates: readonly Tool[];
+	/** The Agent tool itself; omitted when nesting is unavailable. */
+	agentTool?: Tool;
+	isToolEnabled: (name: string) => boolean;
+}
+
+/**
+ * Narrows the parent's tool set to what a sub-agent may call: always-blocked
+ * tools drop out, then the definition's allow/deny lists apply. A definition
+ * that pins `tools` must name the Agent tool to keep spawning sub-agents.
+ */
+export function selectDelegatableTools({
+	definition,
+	candidates,
+	agentTool,
+	isToolEnabled,
+}: SelectDelegatableToolsOptions): Tool[] {
+	const allowed = nameSet(definition.tools);
+	const denied = nameSet(definition.disallowedTools);
+	const permits = (name: string): boolean =>
+		(!allowed || allowed.has(name)) && !denied?.has(name);
+
+	const tools: Tool[] = [];
+	for (const tool of candidates) {
+		if (tool === agentTool) continue;
+		if (NON_DELEGATABLE_AGENT_TOOLS.has(tool.agentName)) continue;
+		if (!permits(tool.agentName)) continue;
+		tools.push(tool);
+	}
+
+	if (
+		agentTool &&
+		permits(agentTool.agentName) &&
+		isToolEnabled(agentTool.agentName)
+	) {
+		tools.push(agentTool);
+	}
+	return tools;
+}
+
+function nameSet(
+	names: readonly string[] | undefined,
+): Set<string> | undefined {
+	return names ? new Set(names.map(canonicalToolName)) : undefined;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -105,11 +105,17 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 		...(deps.backgroundSupervisor
 			? { supervisor: deps.backgroundSupervisor }
 			: {}),
-		createRLMLoop: () =>
+		createRLMLoop: (definition) =>
 			new RLMLoop({
 				client: deps.client,
-				model: deps.config.model,
+				model: definition.model ?? deps.config.model,
 				executor: new LocalReplExecutor(),
+				...(definition.systemPrompt
+					? { instructions: definition.systemPrompt }
+					: {}),
+				...(definition.maxRounds !== undefined
+					? { maxIterations: definition.maxRounds }
+					: {}),
 			}),
 	});
 	holder.tool = agent;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,19 +5,21 @@ import {
 import { LocalReplExecutor } from "../core/agent/rlm/LocalReplExecutor.ts";
 import { RLMLoop } from "../core/agent/rlm/RLMLoop.ts";
 import { SubAgentRunner } from "../core/agent/SubAgentRunner.ts";
+import { AgentCatalog } from "../core/agents/AgentCatalog.ts";
+import { BUILT_IN_AGENTS } from "../core/agents/builtin.ts";
 import type { Tool } from "../core/tools/Tool.ts";
 import { ToolRegistry } from "../core/tools/ToolRegistry.ts";
-import { subagent as subagentPrompt } from "../prompts/system/subagent.tsx";
 import { AgentTool } from "./AgentTool.tsx";
 import {
+	DEFAULT_AGENT_MAX_CONCURRENT,
 	DEFAULT_AGENT_MAX_DEPTH,
-	NON_DELEGATABLE_AGENT_TOOLS,
 } from "./AgentToolConstants.ts";
 import type { DefaultToolDeps } from "./AgentToolTypes.ts";
 import { ApplyPatchTool } from "./ApplyPatchTool.tsx";
 import { AskUserTool } from "./AskUserTool.tsx";
 import { BrowserTool } from "./BrowserTool.tsx";
 import { ComputerTool } from "./ComputerTool.tsx";
+import { selectDelegatableTools } from "./delegatableTools.ts";
 import { EditTool } from "./EditTool.tsx";
 import { ExecuteTool } from "./ExecuteTool.tsx";
 import { FetchUrlTool } from "./FetchUrlTool.tsx";
@@ -66,8 +68,11 @@ export function createDefaultTools(deps?: DefaultToolDeps): Tool[] {
 	return tools;
 }
 
+const BUILT_IN_CATALOG = new AgentCatalog(BUILT_IN_AGENTS);
+
 function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 	const holder: { tool?: AgentTool } = {};
+	const getCatalog = () => deps.getAgentCatalog?.() ?? BUILT_IN_CATALOG;
 
 	const runner = new SubAgentRunner({
 		client: deps.client,
@@ -77,21 +82,14 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 		getThinking: () => resolveRuntimeThinking(deps.config, deps.client),
 		getThinkingResolver: () =>
 			createRuntimeThinkingResolver(deps.config, deps.client),
-		systemPrompt: subagentPrompt.prompt,
-		toolFactory: () => {
-			const tools: Tool[] = [];
-			const availableTools = (deps.getTools?.() ?? base).filter(
-				(tool) => tool !== holder.tool,
-			);
-			const registry = new ToolRegistry([...availableTools]);
-			const workerBaseTools = deps.config.toolPolicy.visibleTools(registry);
-			for (const tool of workerBaseTools) {
-				if (!NON_DELEGATABLE_AGENT_TOOLS.has(tool.agentName)) tools.push(tool);
-			}
-			if (holder.tool && deps.config.isToolEnabled(holder.tool.agentName)) {
-				tools.push(holder.tool);
-			}
-			return tools;
+		toolFactory: ({ definition }) => {
+			const registry = new ToolRegistry([...(deps.getTools?.() ?? base)]);
+			return selectDelegatableTools({
+				definition,
+				candidates: deps.config.toolPolicy.visibleTools(registry),
+				agentTool: holder.tool,
+				isToolEnabled: (name) => deps.config.isToolEnabled(name),
+			});
 		},
 		isToolEnabled: (name) => deps.config.isToolEnabled(name),
 		hookController: deps.hookController,
@@ -101,7 +99,12 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 
 	const agent = new AgentTool({
 		runner,
+		getCatalog,
 		maxDepth: DEFAULT_AGENT_MAX_DEPTH,
+		maxConcurrent: DEFAULT_AGENT_MAX_CONCURRENT,
+		...(deps.backgroundSupervisor
+			? { supervisor: deps.backgroundSupervisor }
+			: {}),
 		createRLMLoop: () =>
 			new RLMLoop({
 				client: deps.client,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,3 +1,4 @@
+import type { ModelRef } from "../config/defaults.ts";
 import {
 	createRuntimeThinkingResolver,
 	resolveRuntimeThinking,
@@ -76,9 +77,11 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 
 	// Sub-agents are where implementation happens, so they run on the execution
 	// model and against the delegated policy — expert mode narrows the parent,
-	// never the worker that has to do the work.
-	const executionView = () => ({
-		model: deps.config.executionModel,
+	// never the worker that has to do the work. An agent that pins `model:`
+	// moves both: the runner sends its turns there, so its thinking metadata
+	// and tool profile must be resolved from that model, not the session's.
+	const executionView = (model: ModelRef) => ({
+		model,
 		thinkingIntent: deps.config.executionThinking,
 	});
 
@@ -87,19 +90,28 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 		getModel: () => deps.config.executionModel,
 		memory: deps.config.memory,
 		memoryProfile: deps.config.memoryProfile,
-		getThinking: () => resolveRuntimeThinking(executionView(), deps.client),
-		getThinkingResolver: () =>
-			createRuntimeThinkingResolver(executionView(), deps.client),
-		toolFactory: ({ definition }) => {
+		getThinking: (model, signal) =>
+			resolveRuntimeThinking(executionView(model), deps.client, undefined, {
+				signal,
+			}),
+		getThinkingResolver: (model, signal) =>
+			createRuntimeThinkingResolver(executionView(model), deps.client, {
+				signal,
+			}),
+		toolFactory: ({ definition, model }) => {
 			const registry = new ToolRegistry([...(deps.getTools?.() ?? base)]);
 			return selectDelegatableTools({
 				definition,
-				candidates: deps.config.delegatedToolPolicy.visibleTools(registry),
+				candidates: deps.config
+					.delegatedToolPolicyFor(model)
+					.visibleTools(registry),
 				agentTool: holder.tool,
-				isToolEnabled: (name) => deps.config.isDelegatedToolEnabled(name),
+				isToolEnabled: (name) =>
+					deps.config.isDelegatedToolEnabled(name, model),
 			});
 		},
-		isToolEnabled: (name) => deps.config.isDelegatedToolEnabled(name),
+		isToolEnabled: (name, model) =>
+			deps.config.isDelegatedToolEnabled(name, model),
 		hookController: deps.hookController,
 		lsp: deps.lsp,
 		checkpoints: deps.checkpoints,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -74,24 +74,32 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 	const holder: { tool?: AgentTool } = {};
 	const getCatalog = () => deps.getAgentCatalog?.() ?? BUILT_IN_CATALOG;
 
+	// Sub-agents are where implementation happens, so they run on the execution
+	// model and against the delegated policy — expert mode narrows the parent,
+	// never the worker that has to do the work.
+	const executionView = () => ({
+		model: deps.config.executionModel,
+		thinkingIntent: deps.config.executionThinking,
+	});
+
 	const runner = new SubAgentRunner({
 		client: deps.client,
-		getModel: () => deps.config.model,
+		getModel: () => deps.config.executionModel,
 		memory: deps.config.memory,
 		memoryProfile: deps.config.memoryProfile,
-		getThinking: () => resolveRuntimeThinking(deps.config, deps.client),
+		getThinking: () => resolveRuntimeThinking(executionView(), deps.client),
 		getThinkingResolver: () =>
-			createRuntimeThinkingResolver(deps.config, deps.client),
+			createRuntimeThinkingResolver(executionView(), deps.client),
 		toolFactory: ({ definition }) => {
 			const registry = new ToolRegistry([...(deps.getTools?.() ?? base)]);
 			return selectDelegatableTools({
 				definition,
-				candidates: deps.config.toolPolicy.visibleTools(registry),
+				candidates: deps.config.delegatedToolPolicy.visibleTools(registry),
 				agentTool: holder.tool,
-				isToolEnabled: (name) => deps.config.isToolEnabled(name),
+				isToolEnabled: (name) => deps.config.isDelegatedToolEnabled(name),
 			});
 		},
-		isToolEnabled: (name) => deps.config.isToolEnabled(name),
+		isToolEnabled: (name) => deps.config.isDelegatedToolEnabled(name),
 		hookController: deps.hookController,
 		lsp: deps.lsp,
 		checkpoints: deps.checkpoints,
@@ -108,7 +116,7 @@ function buildAgentTool(deps: DefaultToolDeps, base: Tool[]): AgentTool {
 		createRLMLoop: (definition) =>
 			new RLMLoop({
 				client: deps.client,
-				model: definition.model ?? deps.config.model,
+				model: definition.model ?? deps.config.executionModel,
 				executor: new LocalReplExecutor(),
 				...(definition.systemPrompt
 					? { instructions: definition.systemPrompt }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1992,6 +1992,7 @@ export function App({
 								model={agent.state.model}
 								thinking={config.thinking}
 								permissionMode={agent.state.permissionMode}
+								backgroundAgents={agent.state.backgroundAgents}
 							/>
 						</>
 					)}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -983,6 +983,15 @@ export function App({
 	);
 	const applyExpertSelection = useCallback(
 		async (selectedModel: ModelInfo, choice: ThinkingChoice) => {
+			if (controller.hasActiveWork) {
+				agent.notice(
+					"Finish or cancel the current turn before changing expert mode.",
+					"error",
+				);
+				setPendingModel(null);
+				setMode("settings");
+				return;
+			}
 			config.setExpertMode({
 				enabled: true,
 				model: {
@@ -1010,7 +1019,7 @@ export function App({
 				setMode("settings");
 			}
 		},
-		[agent, config],
+		[agent, config, controller],
 	);
 	const applyModelSelection = useCallback(
 		async (selectedModel: ModelInfo, choice: ThinkingChoice) => {
@@ -1349,6 +1358,13 @@ export function App({
 	// Enter on the Expert row turns it off when on, and opens the model picker
 	// when off. The pick is remembered, so an off/on cycle re-picks by choice.
 	const toggleExpertMode = useCallback(() => {
+		if (controller.hasActiveWork) {
+			agent.notice(
+				"Finish or cancel the current turn before changing expert mode.",
+				"error",
+			);
+			return;
+		}
 		if (!config.isExpertModeEnabled) {
 			openModelPicker("expert");
 			return;
@@ -1364,7 +1380,7 @@ export function App({
 			);
 		});
 		forceSettingsRender();
-	}, [agent, config, openModelPicker]);
+	}, [agent, config, controller, openModelPicker]);
 	const openSettingsRow = useCallback(
 		(id: SettingsOpenId) => {
 			if (id === "memory") {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1084,7 +1084,7 @@ export function App({
 				// Both branches below rotate the durable session's storage; stop
 				// work bound to the outgoing one first, or a background run
 				// finishing mid-rotation reports into the replacement session.
-				controller.beginSessionReplacement();
+				await controller.beginSessionReplacement();
 				if (hydratedThread.metadata_?.[BYOK_THREAD_METADATA_KEY] === true) {
 					const sessionId =
 						hydratedThread.metadata_?.[BYOK_SESSION_ID_METADATA_KEY];

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -320,9 +320,16 @@ export function App({
 	const [loadingLabel, setLoadingLabel] = useState("Loading");
 	const [models, setModels] = useState<ModelInfo[]>([]);
 	const refreshCredentials = useCallback((): void => {
+		const wasExpert = config.isExpertModeEnabled;
 		refreshClientCredentials(config, client);
+		if (wasExpert && !config.isExpertModeEnabled) {
+			agent.notice(
+				"Expert mode is off: its model's provider key is no longer enabled.",
+				"warning",
+			);
+		}
 		setModels([]);
-	}, [config, client]);
+	}, [agent, config, client]);
 	// Every `/keys` change re-reads credentials into the live Config, so the
 	// next request routes through the new key set without a restart. The model
 	// list is dropped because which models exist depends on those keys.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1034,6 +1034,10 @@ export function App({
 						"A turn started while the session was loading. Cancel it before resuming.",
 					);
 				}
+				// Both branches below rotate the durable session's storage; stop
+				// work bound to the outgoing one first, or a background run
+				// finishing mid-rotation reports into the replacement session.
+				controller.beginSessionReplacement();
 				if (hydratedThread.metadata_?.[BYOK_THREAD_METADATA_KEY] === true) {
 					const sessionId =
 						hydratedThread.metadata_?.[BYOK_SESSION_ID_METADATA_KEY];
@@ -1459,6 +1463,7 @@ export function App({
 					setLoadingLabel("Starting session");
 					setMode("loading");
 					void startNewSession({
+						detach: () => controller.beginSessionReplacement(),
 						activate: onNewSession,
 						resetThread: () => agent.newThread(),
 					})

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -129,6 +129,7 @@ import {
 } from "./components/RewindSelector.tsx";
 import { SessionsSelector } from "./components/SessionsSelector.tsx";
 import {
+	type SettingsOpenId,
 	SettingsPanel,
 	type SettingsState,
 	type SettingsToggleId,
@@ -318,6 +319,10 @@ export function App({
 		[refreshCredentials],
 	);
 	const [pendingModel, setPendingModel] = useState<ModelInfo | null>(null);
+	// One picker serves `/model` and expert mode; this says which one asked.
+	const [modelPickerTarget, setModelPickerTarget] = useState<"main" | "expert">(
+		"main",
+	);
 	const [contextReport, setContextReport] = useState<ContextReport | null>(
 		null,
 	);
@@ -556,19 +561,26 @@ export function App({
 		},
 		[agent, refreshSkillTabs, skillController],
 	);
+	const openModelPicker = useCallback(
+		(target: "main" | "expert") => {
+			setModelPickerTarget(target);
+			setLoadingLabel("Loading models");
+			setMode("loading");
+			void fetchModels(client)
+				.then((result) => {
+					setModels(result);
+					setMode("model");
+				})
+				.catch((err) => {
+					agent.notice(`Failed to load models: ${errorMessage(err)}`, "error");
+					setMode(target === "expert" ? "settings" : "normal");
+				});
+		},
+		[agent, client],
+	);
 	const openModelSelector = useCallback(() => {
-		setLoadingLabel("Loading models");
-		setMode("loading");
-		void fetchModels(client)
-			.then((result) => {
-				setModels(result);
-				setMode("model");
-			})
-			.catch((err) => {
-				agent.notice(`Failed to load models: ${errorMessage(err)}`, "error");
-				setMode("normal");
-			});
-	}, [agent, client]);
+		openModelPicker("main");
+	}, [openModelPicker]);
 	const openSkillsSelector = useCallback(() => {
 		setLoadingLabel("Loading skills");
 		setMode("loading");
@@ -954,8 +966,43 @@ export function App({
 		},
 		[openMcpRegistry],
 	);
+	const applyExpertSelection = useCallback(
+		async (selectedModel: ModelInfo, choice: ThinkingChoice) => {
+			config.setExpertMode({
+				enabled: true,
+				model: {
+					provider: selectedModel.provider,
+					model: selectedModel.model,
+				},
+				thinking: choice.value,
+			});
+			try {
+				await config.saveExpertPreference();
+				agent.notice(
+					`Expert mode on — ${formatModel(config.model)} plans, ${formatModel(
+						selectedModel,
+					)} implements · thinking ${choice.label}`,
+				);
+			} catch (err) {
+				agent.notice(
+					`Expert mode is on for this session, but saving the selection failed: ${errorMessage(
+						err,
+					)}`,
+					"error",
+				);
+			} finally {
+				setPendingModel(null);
+				setMode("settings");
+			}
+		},
+		[agent, config],
+	);
 	const applyModelSelection = useCallback(
 		async (selectedModel: ModelInfo, choice: ThinkingChoice) => {
+			if (modelPickerTarget === "expert") {
+				await applyExpertSelection(selectedModel, choice);
+				return;
+			}
 			controller.setModelContextLimit(selectedModel.contextLimit ?? null);
 			config.setModel({
 				provider: selectedModel.provider,
@@ -980,7 +1027,7 @@ export function App({
 				setMode("normal");
 			}
 		},
-		[agent, config, controller],
+		[agent, applyExpertSelection, config, controller, modelPickerTarget],
 	);
 	const applyModel = useCallback(
 		async (choice: ThinkingChoice) => {
@@ -1280,6 +1327,35 @@ export function App({
 		setMemoryReturnsToSettings(true);
 		setMode("memory");
 	}, []);
+	// Enter on the Expert row turns it off when on, and opens the model picker
+	// when off. The pick is remembered, so an off/on cycle re-picks by choice.
+	const toggleExpertMode = useCallback(() => {
+		if (!config.isExpertModeEnabled) {
+			openModelPicker("expert");
+			return;
+		}
+		config.setExpertMode({ enabled: false });
+		agent.notice(
+			`Expert mode off — ${formatModel(config.model)} implements again.`,
+		);
+		void config.saveExpertPreference().catch((err) => {
+			agent.notice(
+				`Failed to save expert preference: ${errorMessage(err)}`,
+				"error",
+			);
+		});
+		forceSettingsRender();
+	}, [agent, config, openModelPicker]);
+	const openSettingsRow = useCallback(
+		(id: SettingsOpenId) => {
+			if (id === "memory") {
+				openMemoryFromSettings();
+				return;
+			}
+			toggleExpertMode();
+		},
+		[openMemoryFromSettings, toggleExpertMode],
+	);
 	const persistVerbose = useCallback(
 		(next: boolean) => {
 			config.setVerbose(next);
@@ -1339,10 +1415,16 @@ export function App({
 			toggleLsp,
 		],
 	);
+	const modelPickerReturnMode: Mode =
+		modelPickerTarget === "expert" ? "settings" : "normal";
 	const settingsState: SettingsState | null =
 		mode === "settings"
 			? {
 					memory: config.memory,
+					expert: {
+						enabled: config.isExpertModeEnabled,
+						model: config.expertModel ? formatModel(config.expertModel) : null,
+					},
 					verbose: config.isVerbose,
 					notify: config.isNotifyEnabled,
 					lsp: lsp.enabled,
@@ -1758,7 +1840,7 @@ export function App({
 								setPendingModel(model);
 								setMode("thinking");
 							}}
-							onCancel={() => setMode("normal")}
+							onCancel={() => setMode(modelPickerReturnMode)}
 						/>
 					) : mode === "thinking" ? (
 						pendingModel ? (
@@ -1767,7 +1849,7 @@ export function App({
 								onSelect={applyModel}
 								onCancel={() => {
 									setPendingModel(null);
-									setMode("normal");
+									setMode(modelPickerReturnMode);
 								}}
 							/>
 						) : null
@@ -1781,7 +1863,7 @@ export function App({
 						<SettingsPanel
 							state={settingsState}
 							onToggle={toggleSetting}
-							onOpenMemory={openMemoryFromSettings}
+							onOpen={openSettingsRow}
 							onClose={closeSettings}
 						/>
 					) : mode === "skills" ? (

--- a/src/ui/components/SettingsPanel.tsx
+++ b/src/ui/components/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import { SelectRow } from "./SelectRow.tsx";
 
 export interface SettingsState {
 	memory: MemoryMode;
+	expert: ExpertSettingsState;
 	verbose: boolean;
 	notify: boolean;
 	lsp: boolean;
@@ -17,6 +18,14 @@ export interface SettingsState {
 	computerUse: boolean;
 	discover: boolean;
 }
+
+export interface ExpertSettingsState {
+	enabled: boolean;
+	/** The remembered pick, shown even while off so the choice stays visible. */
+	model: string | null;
+}
+
+export type SettingsOpenId = "memory" | "expert";
 
 export type SettingsToggleId =
 	| "verbose"
@@ -28,7 +37,7 @@ export type SettingsToggleId =
 
 export type SettingsRow =
 	| {
-			id: "memory";
+			id: SettingsOpenId;
 			kind: "open";
 			label: string;
 			value: string;
@@ -58,6 +67,13 @@ export function settingsRows(state: SettingsState): SettingsRow[] {
 			label: "Memory",
 			value: MEMORY_LABELS[state.memory],
 			description: "Persistent memory mode",
+		},
+		{
+			id: "expert",
+			kind: "open",
+			label: "Expert",
+			value: expertValue(state.expert),
+			description: "Plan here, implement on a second model",
 		},
 		{
 			id: "verbose",
@@ -105,6 +121,11 @@ export function settingsRows(state: SettingsState): SettingsRow[] {
 	];
 }
 
+function expertValue(expert: ExpertSettingsState): string {
+	if (!expert.enabled || !expert.model) return "Off";
+	return expert.model;
+}
+
 function valueText(row: SettingsRow): string {
 	if (row.kind === "toggle") {
 		if (row.pending) return "○ …";
@@ -116,14 +137,14 @@ function valueText(row: SettingsRow): string {
 interface Props {
 	state: SettingsState;
 	onToggle: (id: SettingsToggleId) => void;
-	onOpenMemory: () => void;
+	onOpen: (id: SettingsOpenId) => void;
 	onClose: () => void;
 }
 
 export function SettingsPanel({
 	state,
 	onToggle,
-	onOpenMemory,
+	onOpen,
 	onClose,
 }: Props): React.ReactElement {
 	const rows = settingsRows(state);
@@ -144,7 +165,7 @@ export function SettingsPanel({
 				if (row.pending) return;
 				onToggle(row.id);
 			} else {
-				onOpenMemory();
+				onOpen(row.id);
 			}
 		}
 	});
@@ -177,7 +198,10 @@ function SettingsRowView({
 	valueWidth: number;
 }): React.ReactElement {
 	const nameColor = selected ? theme.accentBright : theme.subtle;
-	const on = row.kind === "toggle" && row.enabled && !row.pending;
+	const on =
+		row.kind === "toggle"
+			? row.enabled && !row.pending
+			: row.id === "expert" && row.value !== "Off";
 	const valueColor = on
 		? theme.success
 		: selected && row.kind === "open"

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type React from "react";
+import { useEffect, useState } from "react";
 import type { ThinkingConfig, ThinkingIntent } from "../../config/defaults.ts";
 import type { BackgroundRunSnapshot } from "../../core/bus/events.ts";
 import {
@@ -25,6 +26,7 @@ export function StatusBar({
 	backgroundAgents = [],
 }: Props): React.ReactElement {
 	const thinkingAmount = formatThinkingAmount(thinking);
+	const now = useTicker(backgroundAgents.length > 0);
 	const uiTheme = useTheme();
 	const secondary = uiTheme.readableSecondaryText;
 	// Every mode gets a leading glyph: ⏸ for manual (pauses to ask you), ⏵⏵ for
@@ -59,11 +61,21 @@ export function StatusBar({
 			</Box>
 			{backgroundAgents.map((run) => (
 				<Text key={run.id} color={secondary}>
-					{`  ↳ ${run.agent}  ${formatElapsed(run.startedAt)}  ${run.label}`}
+					{`  ↳ ${run.agent}  ${formatElapsed(run.startedAt, now)}  ${run.label}`}
 				</Text>
 			))}
 		</Box>
 	);
+}
+
+function useTicker(active: boolean): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		if (!active) return;
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, [active]);
+	return now;
 }
 
 export function formatBackgroundSummary(

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -88,7 +88,10 @@ export function formatElapsed(startedAt: number, now = Date.now()): string {
 	const seconds = Math.max(0, Math.round((now - startedAt) / 1000));
 	if (seconds < 60) return `${seconds}s`;
 	const minutes = Math.floor(seconds / 60);
-	return `${minutes}m${String(seconds % 60).padStart(2, "0")}s`;
+	if (minutes < 60)
+		return `${minutes}m${String(seconds % 60).padStart(2, "0")}s`;
+	const hours = Math.floor(minutes / 60);
+	return `${hours}h${String(minutes % 60).padStart(2, "0")}m`;
 }
 
 function permissionModeStyle(

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import type React from "react";
 import type { ThinkingConfig, ThinkingIntent } from "../../config/defaults.ts";
+import type { BackgroundRunSnapshot } from "../../core/bus/events.ts";
 import {
 	type PermissionMode,
 	permissionModeLabel,
@@ -14,12 +15,14 @@ interface Props {
 	model: string;
 	thinking: ThinkingConfig | ThinkingIntent | null | undefined;
 	permissionMode: PermissionMode;
+	backgroundAgents?: readonly BackgroundRunSnapshot[];
 }
 
 export function StatusBar({
 	model,
 	thinking,
 	permissionMode,
+	backgroundAgents = [],
 }: Props): React.ReactElement {
 	const thinkingAmount = formatThinkingAmount(thinking);
 	const uiTheme = useTheme();
@@ -29,23 +32,51 @@ export function StatusBar({
 	const { symbol, color } = permissionModeStyle(permissionMode, secondary);
 	const modeDisplay = `${symbol} ${permissionModeLabel(permissionMode)} mode`;
 	return (
-		<Box marginTop={1}>
-			<Text color={color} bold={permissionMode !== "manual"}>
-				{modeDisplay}
-			</Text>
-			<Text color={secondary}>{STATUS_BAR_SEPARATOR}(shift+tab to cycle)</Text>
-			<Text color={secondary}>
-				{STATUS_BAR_SEPARATOR}
-				{model}
-			</Text>
-			{thinkingAmount ? (
+		<Box marginTop={1} flexDirection="column">
+			<Box>
+				<Text color={color} bold={permissionMode !== "manual"}>
+					{modeDisplay}
+				</Text>
+				<Text color={secondary}>
+					{STATUS_BAR_SEPARATOR}(shift+tab to cycle)
+				</Text>
 				<Text color={secondary}>
 					{STATUS_BAR_SEPARATOR}
-					{thinkingAmount}
+					{model}
 				</Text>
-			) : null}
+				{thinkingAmount ? (
+					<Text color={secondary}>
+						{STATUS_BAR_SEPARATOR}
+						{thinkingAmount}
+					</Text>
+				) : null}
+				{backgroundAgents.length > 0 ? (
+					<Text color={theme.accentBright}>
+						{STATUS_BAR_SEPARATOR}
+						{formatBackgroundSummary(backgroundAgents)}
+					</Text>
+				) : null}
+			</Box>
+			{backgroundAgents.map((run) => (
+				<Text key={run.id} color={secondary}>
+					{`  ↳ ${run.agent}  ${formatElapsed(run.startedAt)}  ${run.label}`}
+				</Text>
+			))}
 		</Box>
 	);
+}
+
+export function formatBackgroundSummary(
+	runs: readonly BackgroundRunSnapshot[],
+): string {
+	return `${runs.length} agent${runs.length === 1 ? "" : "s"} running`;
+}
+
+export function formatElapsed(startedAt: number, now = Date.now()): string {
+	const seconds = Math.max(0, Math.round((now - startedAt) / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	return `${minutes}m${String(seconds % 60).padStart(2, "0")}s`;
 }
 
 function permissionModeStyle(

--- a/src/ui/hooks/useAgent.ts
+++ b/src/ui/hooks/useAgent.ts
@@ -30,7 +30,7 @@ type Action =
 	| { type: "hydrate"; messages: readonly Message[] }
 	| { type: "notice"; text: string; level: "info" | "warning" | "error" };
 
-function rootReducer(state: AppState, action: Action): AppState {
+export function rootReducer(state: AppState, action: Action): AppState {
 	switch (action.type) {
 		case "model":
 			return { ...state, model: action.label };
@@ -40,6 +40,7 @@ function rootReducer(state: AppState, action: Action): AppState {
 				transcript: [],
 				todos: [],
 				usage: {},
+				backgroundAgents: [],
 				render: {
 					staticItems: [],
 					liveItems: [],
@@ -57,6 +58,7 @@ function rootReducer(state: AppState, action: Action): AppState {
 				todos: todosFromMessages(action.messages),
 				usage: {},
 				pendingAsk: null,
+				backgroundAgents: [],
 				render: {
 					staticItems: items,
 					liveItems: [],

--- a/src/ui/hooks/useAgent.ts
+++ b/src/ui/hooks/useAgent.ts
@@ -26,7 +26,7 @@ export interface UseAgent {
 type Action =
 	| { type: "event"; event: AgentEvent }
 	| { type: "model"; label: string }
-	| { type: "clear" }
+	| { type: "clear"; scope: "session" | "transcript" }
 	| { type: "hydrate"; messages: readonly Message[] }
 	| { type: "notice"; text: string; level: "info" | "warning" | "error" };
 
@@ -40,7 +40,7 @@ export function rootReducer(state: AppState, action: Action): AppState {
 				transcript: [],
 				todos: [],
 				usage: {},
-				backgroundAgents: [],
+				...(action.scope === "session" ? { backgroundAgents: [] } : {}),
 				render: {
 					staticItems: [],
 					liveItems: [],
@@ -137,10 +137,13 @@ export function useAgent(
 		(label: string) => store.dispatch({ type: "model", label }),
 		[store],
 	);
-	const clear = useCallback(() => store.dispatch({ type: "clear" }), [store]);
+	const clear = useCallback(
+		() => store.dispatch({ type: "clear", scope: "transcript" }),
+		[store],
+	);
 	const newThread = useCallback(() => {
 		controller.newThread();
-		store.dispatch({ type: "clear" });
+		store.dispatch({ type: "clear", scope: "session" });
 	}, [controller, store]);
 	const hydrateTranscript = useCallback(
 		(messages: readonly Message[]) =>

--- a/src/ui/utils/startNewSession.ts
+++ b/src/ui/utils/startNewSession.ts
@@ -1,14 +1,15 @@
 export async function startNewSession(options: {
 	/**
-	 * Stops work bound to the outgoing session BEFORE its storage rotates.
-	 * A background run finishing inside `activate` would otherwise report into
-	 * — and run tools against — the replacement session.
+	 * Stops work bound to the outgoing session BEFORE its storage rotates, and
+	 * resolves once that work has unwound. A background run finishing inside
+	 * `activate` would otherwise report into — and run tools against — the
+	 * replacement session.
 	 */
-	detach: () => void;
+	detach: () => Promise<void>;
 	activate: () => Promise<void>;
 	resetThread: () => void;
 }): Promise<void> {
-	options.detach();
+	await options.detach();
 	await options.activate();
 	options.resetThread();
 }

--- a/src/ui/utils/startNewSession.ts
+++ b/src/ui/utils/startNewSession.ts
@@ -1,7 +1,14 @@
 export async function startNewSession(options: {
+	/**
+	 * Stops work bound to the outgoing session BEFORE its storage rotates.
+	 * A background run finishing inside `activate` would otherwise report into
+	 * — and run tools against — the replacement session.
+	 */
+	detach: () => void;
 	activate: () => Promise<void>;
 	resetThread: () => void;
 }): Promise<void> {
+	options.detach();
 	await options.activate();
 	options.resetThread();
 }

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -1,7 +1,17 @@
+export class SemaphoreAbortError extends Error {
+	constructor() {
+		super("aborted while queued");
+		this.name = "SemaphoreAbortError";
+	}
+}
+
 /** Caps concurrent holders. Acquisitions are granted FIFO. */
 export class Semaphore {
 	private available: number;
-	private readonly waiting: Array<() => void> = [];
+	private readonly waiting: Array<{
+		grant: () => void;
+		reject: (err: Error) => void;
+	}> = [];
 
 	constructor(permits: number) {
 		if (!Number.isInteger(permits) || permits < 1) {
@@ -10,8 +20,8 @@ export class Semaphore {
 		this.available = permits;
 	}
 
-	async run<T>(fn: () => Promise<T>): Promise<T> {
-		await this.acquire();
+	async run<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.acquire(signal);
 		try {
 			return await fn();
 		} finally {
@@ -19,20 +29,34 @@ export class Semaphore {
 		}
 	}
 
-	private acquire(): Promise<void> {
+	private acquire(signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) return Promise.reject(new SemaphoreAbortError());
 		if (this.available > 0) {
 			this.available--;
 			return Promise.resolve();
 		}
-		return new Promise((resolve) => {
-			this.waiting.push(resolve);
+		return new Promise((resolve, reject) => {
+			const entry = {
+				grant: () => {
+					signal?.removeEventListener("abort", onAbort);
+					resolve();
+				},
+				reject,
+			};
+			const onAbort = (): void => {
+				const index = this.waiting.indexOf(entry);
+				if (index >= 0) this.waiting.splice(index, 1);
+				reject(new SemaphoreAbortError());
+			};
+			this.waiting.push(entry);
+			signal?.addEventListener("abort", onAbort, { once: true });
 		});
 	}
 
 	private release(): void {
 		const next = this.waiting.shift();
 		if (next) {
-			next();
+			next.grant();
 			return;
 		}
 		this.available++;

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -8,10 +8,7 @@ export class SemaphoreAbortError extends Error {
 /** Caps concurrent holders. Acquisitions are granted FIFO. */
 export class Semaphore {
 	private available: number;
-	private readonly waiting: Array<{
-		grant: () => void;
-		reject: (err: Error) => void;
-	}> = [];
+	private readonly waiting: Array<{ grant: () => void }> = [];
 
 	constructor(permits: number) {
 		if (!Number.isInteger(permits) || permits < 1) {
@@ -41,7 +38,6 @@ export class Semaphore {
 					signal?.removeEventListener("abort", onAbort);
 					resolve();
 				},
-				reject,
 			};
 			const onAbort = (): void => {
 				const index = this.waiting.indexOf(entry);

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -1,0 +1,40 @@
+/** Caps concurrent holders. Acquisitions are granted FIFO. */
+export class Semaphore {
+	private available: number;
+	private readonly waiting: Array<() => void> = [];
+
+	constructor(permits: number) {
+		if (!Number.isInteger(permits) || permits < 1) {
+			throw new Error("Semaphore requires at least one permit");
+		}
+		this.available = permits;
+	}
+
+	async run<T>(fn: () => Promise<T>): Promise<T> {
+		await this.acquire();
+		try {
+			return await fn();
+		} finally {
+			this.release();
+		}
+	}
+
+	private acquire(): Promise<void> {
+		if (this.available > 0) {
+			this.available--;
+			return Promise.resolve();
+		}
+		return new Promise((resolve) => {
+			this.waiting.push(resolve);
+		});
+	}
+
+	private release(): void {
+		const next = this.waiting.shift();
+		if (next) {
+			next();
+			return;
+		}
+		this.available++;
+	}
+}

--- a/tests/AgentTool.test.ts
+++ b/tests/AgentTool.test.ts
@@ -8,6 +8,8 @@ import type {
 	SubAgentResult,
 	SubAgentRunParams,
 } from "../src/core/agent/SubAgentRunner.ts";
+import { AgentCatalog } from "../src/core/agents/AgentCatalog.ts";
+import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
 import { EventBus } from "../src/core/bus/EventBus.ts";
 import type { OpenAITool } from "../src/core/tools/schema.ts";
 import type { ToolContext } from "../src/core/tools/ToolContext.ts";
@@ -68,7 +70,9 @@ function makeTool(
 	const tool = new AgentTool({
 		runner,
 		createRLMLoop: () => rlmLoop,
+		getCatalog: () => new AgentCatalog(BUILT_IN_AGENTS),
 		maxDepth: 2,
+		maxConcurrent: 8,
 		...overrides,
 	});
 	return { tool, workerCalls, rlmCalls };
@@ -83,11 +87,36 @@ describe("AgentTool schema and flags", () => {
 		expect(parsed.subagent_type).toBeUndefined();
 	});
 
-	it("rejects unsupported subagent types", () => {
+	it("rejects subagent types absent from the catalog", async () => {
 		const { tool } = makeTool();
-		expect(() =>
-			tool.parseInput({ prompt: "do it", subagent_type: "planner" }),
-		).toThrow();
+		await expect(
+			tool.execute({ prompt: "do it", subagent_type: "planner" }, ctx(0)),
+		).rejects.toThrow("Unknown subagent_type 'planner'");
+	});
+
+	it("advertises catalog agents in the schema enum and description", () => {
+		const { tool } = makeTool({
+			getCatalog: () =>
+				new AgentCatalog([
+					...BUILT_IN_AGENTS,
+					{
+						name: "researcher",
+						description: "Deep-dives one question.",
+						mode: "worker",
+						systemPrompt: "You research.",
+						source: "project",
+					},
+				]),
+		});
+		const parameters = tool.toJSONSchema().function.parameters as {
+			properties?: { subagent_type?: { enum?: string[] } };
+		};
+		expect(parameters.properties?.subagent_type?.enum).toEqual([
+			"worker",
+			"rlm",
+			"researcher",
+		]);
+		expect(tool.prompt()).toContain("`researcher`: Deep-dives one question.");
 	});
 
 	it("emits a Backboard-compatible variables object schema", () => {

--- a/tests/CheckpointStore.test.ts
+++ b/tests/CheckpointStore.test.ts
@@ -17,6 +17,7 @@ import { sha256Hex } from "../src/core/checkpoints/blobStore.ts";
 import {
 	CheckpointStore,
 	MAX_CAPTURE_BYTES,
+	revocableRecorder,
 } from "../src/core/checkpoints/CheckpointStore.ts";
 import type { SessionPaths } from "../src/core/session/SessionStore.ts";
 
@@ -605,5 +606,65 @@ describe("CheckpointStore", () => {
 		await undoLatest(store);
 
 		expect(events).toEqual([{ checkpointId: "t1", files: 1 }]);
+	});
+});
+
+describe("revocableRecorder", () => {
+	it("stops journaling into the turn once revoked", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		revoke();
+		await recorder.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		await recorder.recordPostImage(file, ctx("t1", "c1"), Buffer.from("v1"));
+		endTurn(bus, "t1");
+
+		expect(store.listCheckpoints()).toHaveLength(0);
+	});
+
+	it("still rolls back a tool call it pre-imaged before revocation", async () => {
+		const { bus, store } = makeStore();
+		const fileA = join(work, "a.txt");
+		const fileB = join(work, "b.txt");
+		await writeFile(fileA, "a v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		await recorder.recordPreImage(fileA, ctx("t1", "c1"), {
+			tool: "ApplyPatch",
+		});
+		await recorder.recordPreImage(fileB, ctx("t1", "c1"), {
+			tool: "ApplyPatch",
+		});
+		await writeFile(fileA, "a v1", "utf8");
+		await recorder.recordPostImage(fileA, ctx("t1", "c1"), Buffer.from("a v1"));
+		await writeFile(fileB, "b created", "utf8");
+
+		revoke();
+		await recorder.revertToolCall("c1");
+
+		expect(await readFile(fileA, "utf8")).toBe("a v0");
+		expect(existsSync(fileB)).toBe(false);
+	});
+
+	it("revokes recorders a nested run re-scoped from it", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		const nested = recorder.scopedToTurn("subagent-turn");
+		revoke();
+		await nested.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		await nested.recordPostImage(file, ctx("t1", "c1"), Buffer.from("v1"));
+		endTurn(bus, "t1");
+
+		expect(store.listCheckpoints()).toHaveLength(0);
 	});
 });

--- a/tests/CheckpointStore.test.ts
+++ b/tests/CheckpointStore.test.ts
@@ -66,6 +66,12 @@ function endTurn(bus: EventBus, turnId: string): void {
 
 const ctx = (turnId: string, toolCallId: string) => ({ turnId, toolCallId });
 
+/** Reaches the private per-tool-call begin snapshots to assert they are freed. */
+function shellBeginCount(store: CheckpointStore): number {
+	return (store as unknown as { shellBegins: Map<string, unknown> }).shellBegins
+		.size;
+}
+
 async function undoLatest(store: CheckpointStore, skipDiverged = false) {
 	const target = store.undoTarget();
 	if (!target) throw new Error("expected an undo target");
@@ -649,6 +655,112 @@ describe("revocableRecorder", () => {
 
 		expect(await readFile(fileA, "utf8")).toBe("a v0");
 		expect(existsSync(fileB)).toBe(false);
+	});
+
+	it("drops a pre-image whose write was still pending when it was revoked", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		// The capture returns, then the run is backgrounded before its write.
+		await recorder.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await revoke();
+		await writeFile(file, "background result", "utf8");
+		await recorder.recordPostImage(file, ctx("t1", "c1"), Buffer.from("bg"));
+		endTurn(bus, "t1");
+
+		// Nothing left for the turn to own, so /undo cannot clobber the write.
+		expect(store.listCheckpoints()).toHaveLength(0);
+		expect(await readFile(file, "utf8")).toBe("background result");
+	});
+
+	it("keeps a pre-image its post-image already settled", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		await recorder.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		await recorder.recordPostImage(file, ctx("t1", "c1"), Buffer.from("v1"));
+		await revoke();
+		endTurn(bus, "t1");
+
+		expect(store.listCheckpoints()).toHaveLength(1);
+		await undoLatest(store);
+		expect(await readFile(file, "utf8")).toBe("v0");
+	});
+
+	it("ignores a revoke for an entry journaled by another session's store", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		await store.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		await store.recordPostImage(file, ctx("t1", "c1"), Buffer.from("v1"));
+		endTurn(bus, "t1");
+
+		// A run that outlived a session switch revokes through the manager into
+		// this store with a seq that only meant something in its own journal.
+		const foreign = store.listCheckpoints()[0];
+		expect(foreign).toBeDefined();
+		await store.revokeCapture({
+			journalRoot: join(root, "elsewhere"),
+			turnId: "t1",
+			ref: 1,
+			path: file,
+		});
+
+		expect(store.listCheckpoints()).toHaveLength(1);
+		await undoLatest(store);
+		expect(await readFile(file, "utf8")).toBe("v0");
+	});
+
+	it("keeps a write that finished before revocation even if its post-image had not landed", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		await recorder.recordPreImage(file, ctx("t1", "c1"), { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		// The handoff lands while the post-image is still being recorded.
+		const post = recorder.recordPostImage(file, ctx("t1", "c1"));
+		await revoke();
+		await post;
+		endTurn(bus, "t1");
+
+		// The write happened under the turn, so /undo still owns it.
+		expect(store.listCheckpoints()).toHaveLength(1);
+		await undoLatest(store);
+		expect(await readFile(file, "utf8")).toBe("v0");
+	});
+
+	it("releases the shell begin snapshot when end runs after revocation", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "sh.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		await recorder.beginShellCapture(work, ctx("t1", "c1"));
+		await revoke();
+		await writeFile(file, "v1", "utf8");
+		await recorder.endShellCapture(ctx("t1", "c1"));
+		endTurn(bus, "t1");
+
+		// Journaling stayed suppressed...
+		expect(store.listCheckpoints()).toHaveLength(0);
+		// ...but the begin snapshot was released, so a later end is a no-op
+		// rather than a diff against a baseline that outlived the run.
+		await recorder.endShellCapture(ctx("t1", "c1"));
+		expect(shellBeginCount(store)).toBe(0);
 	});
 
 	it("rejects a revoked requireRevertible capture before any write happens", async () => {

--- a/tests/CheckpointStore.test.ts
+++ b/tests/CheckpointStore.test.ts
@@ -763,6 +763,29 @@ describe("revocableRecorder", () => {
 		expect(shellBeginCount(store)).toBe(0);
 	});
 
+	it("does not attribute a revoked command's writes to the next command", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "sh.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		await recorder.beginShellCapture(work, ctx("t1", "c1"));
+		await revoke();
+		await writeFile(file, "v1", "utf8");
+		await recorder.endShellCapture(ctx("t1", "c1"));
+		endTurn(bus, "t1");
+
+		startTurn(bus, "t2");
+		const foreground = store.scopedToTurn("t2");
+		await foreground.beginShellCapture(work, ctx("t2", "c2"));
+		await foreground.endShellCapture(ctx("t2", "c2"));
+		endTurn(bus, "t2");
+
+		expect(store.listCheckpoints()).toHaveLength(0);
+		expect(await readFile(file, "utf8")).toBe("v1");
+	});
+
 	it("rejects a revoked requireRevertible capture before any write happens", async () => {
 		const { bus, store } = makeStore();
 		const file = join(work, "f.txt");

--- a/tests/CheckpointStore.test.ts
+++ b/tests/CheckpointStore.test.ts
@@ -651,6 +651,60 @@ describe("revocableRecorder", () => {
 		expect(existsSync(fileB)).toBe(false);
 	});
 
+	it("rejects a revoked requireRevertible capture before any write happens", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		revoke();
+
+		await expect(
+			recorder.recordPreImage(file, ctx("t1", "c1"), {
+				tool: "ApplyPatch",
+				requireRevertible: true,
+			}),
+		).rejects.toThrow(/rolled back/);
+	});
+
+	it("drops a capture that was in flight when it was revoked", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		// Revocation lands while the capture's file I/O is still pending.
+		const capture = recorder.recordPreImage(file, ctx("t1", "c1"), {
+			tool: "Edit",
+		});
+		revoke();
+		await capture;
+		await writeFile(file, "v1", "utf8");
+		await recorder.recordPostImage(file, ctx("t1", "c1"), Buffer.from("v1"));
+		endTurn(bus, "t1");
+
+		expect(store.listCheckpoints()).toHaveLength(0);
+	});
+
+	it("rejects an in-flight requireRevertible capture once revoked", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		const capture = recorder.recordPreImage(file, ctx("t1", "c1"), {
+			tool: "ApplyPatch",
+			requireRevertible: true,
+		});
+		revoke();
+
+		await expect(capture).rejects.toThrow(/rolled back/);
+		expect(store.listCheckpoints()).toHaveLength(0);
+	});
+
 	it("revokes recorders a nested run re-scoped from it", async () => {
 		const { bus, store } = makeStore();
 		const file = join(work, "f.txt");

--- a/tests/CheckpointStore.test.ts
+++ b/tests/CheckpointStore.test.ts
@@ -705,6 +705,61 @@ describe("revocableRecorder", () => {
 		expect(store.listCheckpoints()).toHaveLength(0);
 	});
 
+	it("drops a capture revoked while its journal flush was pending", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		// Revocation lands after the last in-capture check, while the journal
+		// flush is still in flight: the pre-image is already durable but the
+		// post-image will be suppressed.
+		let checks = 0;
+		const racing = {
+			...ctx("t1", "c1"),
+			mayJournal: () => {
+				if (++checks === 2) revoke();
+				return true;
+			},
+		};
+		await recorder.recordPreImage(file, racing, { tool: "Edit" });
+		await writeFile(file, "v1", "utf8");
+		await recorder.recordPostImage(file, racing, Buffer.from("v1"));
+		endTurn(bus, "t1");
+
+		// The background run's write must not be revertible through the
+		// foreground turn's checkpoint.
+		expect(store.listCheckpoints()).toHaveLength(0);
+		expect(store.undoTarget()).toBeNull();
+	});
+
+	it("rejects a requireRevertible capture revoked during its flush", async () => {
+		const { bus, store } = makeStore();
+		const file = join(work, "f.txt");
+		await writeFile(file, "v0", "utf8");
+
+		startTurn(bus, "t1");
+		const { recorder, revoke } = revocableRecorder(store.scopedToTurn("t1"));
+		let checks = 0;
+		const racing = {
+			...ctx("t1", "c1"),
+			mayJournal: () => {
+				if (++checks === 2) revoke();
+				return true;
+			},
+		};
+
+		await expect(
+			recorder.recordPreImage(file, racing, {
+				tool: "ApplyPatch",
+				requireRevertible: true,
+			}),
+		).rejects.toThrow(/rolled back/);
+		endTurn(bus, "t1");
+		expect(store.listCheckpoints()).toHaveLength(0);
+	});
+
 	it("revokes recorders a nested run re-scoped from it", async () => {
 		const { bus, store } = makeStore();
 		const file = join(work, "f.txt");

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -27,7 +27,10 @@ import {
 	qUserHookConfigPath,
 	qUserMcpConfigPath,
 } from "../src/config/paths.ts";
-import { setProviderKey } from "../src/core/keys/ProviderKeyStore.ts";
+import {
+	setProviderKey,
+	setProviderKeyEnabled,
+} from "../src/core/keys/ProviderKeyStore.ts";
 
 const env = { apiKey: "test-key", apiUrl: "https://example.test/api" };
 
@@ -80,6 +83,35 @@ describe("Config", () => {
 			const reopened = new Config({ argv: [], homeDir });
 			expect(reopened.isExpertModeEnabled).toBe(true);
 			expect(reopened.startupWarnings).toHaveLength(0);
+		});
+	});
+
+	it("disables expert mode when an auth refresh drops its provider key", async () => {
+		await withBackboardEnv({}, async () => {
+			const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-config-"));
+			await saveBackboardConfig(
+				{
+					model: { provider: "anthropic", model: "claude-opus-4.8" },
+					expert: {
+						enabled: true,
+						model: { provider: "openai", model: "gpt-6" },
+					},
+				},
+				homeDir,
+			);
+			await setProviderKey("anthropic", "sk-a", homeDir);
+			await setProviderKey("openai", "sk-o", homeDir);
+
+			const config = new Config({ argv: [], homeDir });
+			expect(config.isExpertModeEnabled).toBe(true);
+
+			await setProviderKeyEnabled("openai", false, homeDir);
+			config.refreshAuth();
+			expect(config.isExpertModeEnabled).toBe(false);
+			expect(config.expertModel).toEqual({
+				provider: "openai",
+				model: "gpt-6",
+			});
 		});
 	});
 

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -53,6 +53,36 @@ describe("Config", () => {
 		expect(config.memoryProfile).toBe("code");
 	});
 
+	it("disables persisted expert mode when its provider has no enabled key", async () => {
+		await withBackboardEnv({}, async () => {
+			const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-config-"));
+			await saveBackboardConfig(
+				{
+					model: { provider: "anthropic", model: "claude-opus-4.8" },
+					expert: {
+						enabled: true,
+						model: { provider: "openai", model: "gpt-6" },
+					},
+				},
+				homeDir,
+			);
+			await setProviderKey("anthropic", "sk-a", homeDir);
+
+			const config = new Config({ argv: [], homeDir });
+			expect(config.isExpertModeEnabled).toBe(false);
+			expect(config.expertModel).toEqual({
+				provider: "openai",
+				model: "gpt-6",
+			});
+			expect(config.startupWarnings).toHaveLength(1);
+
+			await setProviderKey("openai", "sk-o", homeDir);
+			const reopened = new Config({ argv: [], homeDir });
+			expect(reopened.isExpertModeEnabled).toBe(true);
+			expect(reopened.startupWarnings).toHaveLength(0);
+		});
+	});
+
 	it("persists a stable project workspace id in the project config", async () => {
 		const dir = await mkdtemp(path.join(os.tmpdir(), "cli-workspace-"));
 		const child = path.join(dir, "packages", "app");

--- a/tests/ExecuteToolCapture.test.ts
+++ b/tests/ExecuteToolCapture.test.ts
@@ -16,6 +16,9 @@ function makeRecorder(): { recorder: CheckpointRecorder; calls: string[] } {
 		recordPostImage: async () => {
 			calls.push("post");
 		},
+		revokeCapture: async () => {
+			calls.push("revoke");
+		},
 		revertToolCall: async () => {
 			calls.push("revert");
 		},

--- a/tests/ExpertMode.test.ts
+++ b/tests/ExpertMode.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BackboardConfigFile } from "../src/config/BackboardConfigTypes.ts";
+import {
+	readBackboardConfig,
+	saveBackboardConfig,
+} from "../src/config/backboardConfig.ts";
+import { Config } from "../src/config/Config.ts";
+import { EXPERT_EXECUTION_TOOLS } from "../src/core/tools/ToolPolicy.ts";
+
+const env = { apiKey: "test-key", apiUrl: "https://example.test/api" };
+const OPUS = { provider: "anthropic", model: "claude-opus-4.8" };
+const KIMI = { provider: "moonshot", model: "kimi-k3" };
+
+async function configWith(file: BackboardConfigFile): Promise<Config> {
+	const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+	await saveBackboardConfig({ model: OPUS, ...file }, homeDir);
+	return new Config({ env, argv: [], homeDir });
+}
+
+describe("expert mode selection", () => {
+	it("is off by default and executes on the main model", async () => {
+		const config = await configWith({});
+		expect(config.isExpertModeEnabled).toBe(false);
+		expect(config.expertModel).toBeNull();
+		expect(config.executionModel).toEqual(OPUS);
+	});
+
+	it("loads a persisted expert selection", async () => {
+		const config = await configWith({
+			expert: {
+				enabled: true,
+				model: KIMI,
+				thinking: { kind: "level", level: "high" },
+			},
+		});
+		expect(config.isExpertModeEnabled).toBe(true);
+		expect(config.expertModel).toEqual(KIMI);
+		expect(config.executionThinking).toEqual({ kind: "level", level: "high" });
+	});
+
+	it("splits planning and execution across the two models", async () => {
+		const config = await configWith({
+			expert: { enabled: true, model: KIMI },
+		});
+		expect(config.model).toEqual(OPUS);
+		expect(config.executionModel).toEqual(KIMI);
+	});
+
+	it("stays off when enabled without a model", async () => {
+		const config = await configWith({ expert: { enabled: true } });
+		expect(config.isExpertModeEnabled).toBe(false);
+		expect(config.executionModel).toEqual(OPUS);
+	});
+
+	it("falls back to the main thinking intent when expert mode is off", async () => {
+		const config = await configWith({
+			thinking: { kind: "level", level: "low" },
+			expert: { enabled: false, model: KIMI },
+		});
+		expect(config.executionThinking).toEqual({ kind: "level", level: "low" });
+	});
+
+	it("persists a selection made at runtime", async () => {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+		await saveBackboardConfig({ model: OPUS }, homeDir);
+		const config = new Config({ env, argv: [], homeDir });
+
+		config.setExpertMode({
+			enabled: true,
+			model: KIMI,
+			thinking: { kind: "dynamic" },
+		});
+		await config.saveExpertPreference();
+
+		expect(readBackboardConfig(homeDir).expert).toEqual({
+			enabled: true,
+			model: KIMI,
+			thinking: { kind: "dynamic" },
+		});
+		// The main /model selection is untouched by an expert change.
+		expect(readBackboardConfig(homeDir).model).toEqual(OPUS);
+	});
+
+	it("keeps the remembered model when expert mode is switched off", async () => {
+		const config = await configWith({
+			expert: { enabled: true, model: KIMI },
+		});
+		config.setExpertMode({ enabled: false });
+		expect(config.isExpertModeEnabled).toBe(false);
+		expect(config.expertModel).toEqual(KIMI);
+		expect(config.executionModel).toEqual(OPUS);
+	});
+});
+
+describe("expert mode tool policy", () => {
+	it("hides the implementation tools from the main model", async () => {
+		const config = await configWith({
+			expert: { enabled: true, model: KIMI },
+		});
+		for (const name of EXPERT_EXECUTION_TOOLS) {
+			expect(config.isToolEnabled(name)).toBe(false);
+			expect(config.toolSchemaExcludedNames).toContain(name);
+		}
+	});
+
+	it("keeps the agent tool so the main model can still delegate", async () => {
+		const config = await configWith({
+			expert: { enabled: true, model: KIMI },
+		});
+		expect(config.isToolEnabled("agent")).toBe(true);
+		expect(config.isToolEnabled("read")).toBe(true);
+		expect(config.isToolEnabled("grep")).toBe(true);
+	});
+
+	it("leaves the implementation tools with the sub-agent", async () => {
+		const on = await configWith({ expert: { enabled: true, model: KIMI } });
+		expect(on.isDelegatedToolEnabled("edit")).toBe(true);
+		expect(on.isDelegatedToolEnabled("write")).toBe(true);
+		expect(on.isDelegatedToolEnabled("execute")).toBe(true);
+	});
+
+	it("gives the sub-agent the tools the expert model's profile wants", async () => {
+		// The planner is an OpenAI model, whose profile swaps edit/write for
+		// apply_patch. The executor is not, so it must get edit/write instead.
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+		await saveBackboardConfig(
+			{ model: { provider: "openai", model: "gpt-5" } },
+			homeDir,
+		);
+		const config = new Config({ env, argv: [], homeDir });
+		config.setExpertMode({ enabled: true, model: KIMI });
+
+		expect(config.modelProfile.name).toBe("openai");
+		expect(config.executionModelProfile.name).toBe("default");
+		expect(config.isDelegatedToolEnabled("edit")).toBe(true);
+		expect(config.isDelegatedToolEnabled("write")).toBe(true);
+		expect(config.isDelegatedToolEnabled("apply_patch")).toBe(false);
+	});
+
+	it("hands the sub-agent the planner's profile when expert mode is off", async () => {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+		await saveBackboardConfig(
+			{ model: { provider: "openai", model: "gpt-5" } },
+			homeDir,
+		);
+		const config = new Config({ env, argv: [], homeDir });
+
+		expect(config.executionModelProfile.name).toBe("openai");
+		expect(config.isDelegatedToolEnabled("edit")).toBe(false);
+		expect(config.isDelegatedToolEnabled("apply_patch")).toBe(true);
+	});
+
+	it("only withholds what expert mode named", async () => {
+		const on = await configWith({ expert: { enabled: true, model: KIMI } });
+		const off = await configWith({ expert: { enabled: false, model: KIMI } });
+		const alreadyExcluded = new Set(off.toolPolicy.schemaExcludedNames());
+		const added = on.toolPolicy
+			.schemaExcludedNames()
+			.filter((name) => !alreadyExcluded.has(name));
+		expect(added.sort()).toEqual(
+			EXPERT_EXECUTION_TOOLS.filter(
+				(name) => !alreadyExcluded.has(name),
+			).sort(),
+		);
+	});
+
+	it("restores the implementation tools when expert mode is off", async () => {
+		const config = await configWith({
+			expert: { enabled: false, model: KIMI },
+		});
+		expect(config.isToolEnabled("edit")).toBe(true);
+		expect(config.isToolEnabled("write")).toBe(true);
+		expect(config.isToolEnabled("execute")).toBe(true);
+	});
+
+	it("takes effect as soon as the toggle flips", async () => {
+		const config = await configWith({});
+		expect(config.isToolEnabled("edit")).toBe(true);
+		config.setExpertMode({ enabled: true, model: KIMI });
+		expect(config.isToolEnabled("edit")).toBe(false);
+		config.setExpertMode({ enabled: false });
+		expect(config.isToolEnabled("edit")).toBe(true);
+	});
+});

--- a/tests/ExpertMode.test.ts
+++ b/tests/ExpertMode.test.ts
@@ -84,6 +84,27 @@ describe("expert mode selection", () => {
 		expect(readBackboardConfig(homeDir).model).toEqual(OPUS);
 	});
 
+	it("keeps concurrent preference saves from clobbering each other", async () => {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+		await saveBackboardConfig({ model: OPUS }, homeDir);
+		const config = new Config({ env, argv: [], homeDir });
+
+		config.setExpertMode({
+			enabled: true,
+			model: KIMI,
+			thinking: { kind: "dynamic" },
+		});
+		config.setVerbose(true);
+		await Promise.all([
+			config.saveExpertPreference(),
+			config.saveVerbosePreference(),
+		]);
+
+		const saved = readBackboardConfig(homeDir);
+		expect(saved.expert?.enabled).toBe(true);
+		expect(saved.verbose).toBe(true);
+	});
+
 	it("keeps the remembered model when expert mode is switched off", async () => {
 		const config = await configWith({
 			expert: { enabled: true, model: KIMI },

--- a/tests/ExpertMode.test.ts
+++ b/tests/ExpertMode.test.ts
@@ -153,6 +153,25 @@ describe("expert mode tool policy", () => {
 		expect(config.isDelegatedToolEnabled("apply_patch")).toBe(true);
 	});
 
+	it("resolves a custom agent's tools from the model it pins", async () => {
+		// The session is OpenAI, whose profile swaps edit/write for apply_patch.
+		// An agent that pins a Moonshot model sends its turns there, so it must
+		// get that model's tools rather than the session's.
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-expert-"));
+		await saveBackboardConfig(
+			{ model: { provider: "openai", model: "gpt-5" } },
+			homeDir,
+		);
+		const config = new Config({ env, argv: [], homeDir });
+
+		expect(config.isDelegatedToolEnabled("apply_patch")).toBe(true);
+		expect(config.isDelegatedToolEnabled("apply_patch", KIMI)).toBe(false);
+		expect(config.isDelegatedToolEnabled("edit", KIMI)).toBe(true);
+		expect(config.delegatedToolPolicyFor(KIMI).isRuntimeAllowed("write")).toBe(
+			true,
+		);
+	});
+
 	it("only withholds what expert mode named", async () => {
 		const on = await configWith({ expert: { enabled: true, model: KIMI } });
 		const off = await configWith({ expert: { enabled: false, model: KIMI } });

--- a/tests/PermissionResolve.test.ts
+++ b/tests/PermissionResolve.test.ts
@@ -135,6 +135,29 @@ describe("escalated permission prompts", () => {
 		expect(result.denialReason).toContain("unavailable");
 	});
 
+	it("settles an escalated prompt aborted by handoff as a denial", async () => {
+		const cwd = await tempProject();
+		let backgrounded = false;
+		const ctx = makeCtx({
+			cwd,
+			permissions: pctxWith(() =>
+				backgrounded
+					? null
+					: async () => {
+							backgrounded = true;
+							throw new Error("aborted");
+						},
+			),
+		});
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(false);
+		expect(result.denialReason).toContain("unavailable");
+	});
+
 	it("honors a deny answer from the escalated prompt", async () => {
 		const cwd = await tempProject();
 		const ctx = makeCtx({

--- a/tests/PermissionResolve.test.ts
+++ b/tests/PermissionResolve.test.ts
@@ -65,6 +65,68 @@ function makeCtx(opts: {
 	};
 }
 
+describe("escalated permission prompts", () => {
+	const pctxWith = (
+		escalate: PermissionContext["escalate"],
+	): PermissionContext => ({
+		mode: "manual",
+		rules: parseRuleSet({}),
+		interactive: false,
+		escalate,
+	});
+
+	it("routes a non-interactive ask through the escalation channel", async () => {
+		const cwd = await tempProject();
+		const ctx = makeCtx({
+			cwd,
+			permissions: pctxWith(() => async () => ALLOW_ONCE),
+		});
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(true);
+	});
+
+	it("denies the ask when the escalation channel is gone", async () => {
+		const cwd = await tempProject();
+		const ctx = makeCtx({ cwd, permissions: pctxWith(() => null) });
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(false);
+		expect(result.denialReason).toContain("unavailable");
+	});
+
+	it("still denies without any escalation channel", async () => {
+		const cwd = await tempProject();
+		const ctx = makeCtx({ cwd, permissions: pctxWith(undefined) });
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(false);
+	});
+
+	it("honors a deny answer from the escalated prompt", async () => {
+		const cwd = await tempProject();
+		const ctx = makeCtx({
+			cwd,
+			permissions: pctxWith(() => async () => DENY),
+		});
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(false);
+	});
+});
+
 describe("suggestRule", () => {
 	it("builds a two-token prefix rule for commands", () => {
 		expect(suggestRule("execute", "cargo build --release")).toBe(

--- a/tests/PermissionResolve.test.ts
+++ b/tests/PermissionResolve.test.ts
@@ -112,6 +112,29 @@ describe("escalated permission prompts", () => {
 		expect(result.allowed).toBe(false);
 	});
 
+	it("denies an approval that lands after the chain backgrounds", async () => {
+		const cwd = await tempProject();
+		let backgrounded = false;
+		const ctx = makeCtx({
+			cwd,
+			permissions: pctxWith(() =>
+				backgrounded
+					? null
+					: async () => {
+							backgrounded = true;
+							return ALLOW_ONCE;
+						},
+			),
+		});
+		const result = await resolveToolPermission(
+			new MutatingTool(),
+			{ command: "touch a" },
+			ctx,
+		);
+		expect(result.allowed).toBe(false);
+		expect(result.denialReason).toContain("unavailable");
+	});
+
 	it("honors a deny answer from the escalated prompt", async () => {
 		const cwd = await tempProject();
 		const ctx = makeCtx({

--- a/tests/RLMLoop.test.ts
+++ b/tests/RLMLoop.test.ts
@@ -152,6 +152,7 @@ interface LoopOptions {
 	maxIterations?: number;
 	maxLLMCalls?: number;
 	timeoutSummaryMs?: number;
+	instructions?: string;
 }
 
 function loopWith(
@@ -411,5 +412,53 @@ describe("RLMLoop", () => {
 
 		expect(result.report).toContain("llm_query budget exceeded (2)");
 		expect(client.requests).toHaveLength(1);
+	});
+});
+
+describe("RLMLoop custom agent instructions", () => {
+	it("prepends them to the action prompt", async () => {
+		const client = new ScriptedClient([response("```js\nSUBMIT('done')\n```")]);
+		const executor = new FakeExecutor([
+			{ ok: true, stdout: "", stderr: "", submitted: "done" },
+		]);
+		await loopWith(client, executor, {
+			instructions: "You are a schema auditor. Answer in one line.",
+		}).run(runParams("audit this"));
+
+		expect(client.requests[0]?.content).toStartWith(
+			"You are a schema auditor. Answer in one line.\n\n",
+		);
+	});
+
+	it("keeps them out of llm_query sub-calls the REPL makes", async () => {
+		const client = new ScriptedClient([
+			response(
+				"```js\nconst r = await llm_query('inner question'); SUBMIT(r)\n```",
+			),
+			response("LEAF ANSWER"),
+		]);
+		await loopWith(client, new LocalReplExecutor(), {
+			instructions: "You are a schema auditor.",
+		}).run(runParams("audit this"));
+
+		expect(client.requests[1]?.content).toBe("inner question");
+	});
+
+	it("stops at the agent's configured iteration count", async () => {
+		const client = new ScriptedClient([
+			response("```js\nprint(1)\n```"),
+			response("the extracted answer"),
+		]);
+		const executor = new FakeExecutor([{ ok: true, stdout: "1", stderr: "" }]);
+		const result = await loopWith(client, executor, {
+			maxIterations: 1,
+			instructions: "You are a schema auditor.",
+		}).run(runParams("audit this"));
+
+		expect(result.rounds).toBe(1);
+		expect(result.report).toBe("the extracted answer");
+		expect(client.requests[1]?.content).toStartWith(
+			"You are a schema auditor.",
+		);
 	});
 });

--- a/tests/SettingsPanel.interaction.test.ts
+++ b/tests/SettingsPanel.interaction.test.ts
@@ -4,6 +4,7 @@ import { Writable } from "node:stream";
 import { render } from "ink";
 import React from "react";
 import {
+	type SettingsOpenId,
 	SettingsPanel,
 	type SettingsState,
 	type SettingsToggleId,
@@ -11,6 +12,7 @@ import {
 
 const BASE: SettingsState = {
 	memory: "auto",
+	expert: { enabled: false, model: null },
 	verbose: false,
 	notify: false,
 	lsp: false,
@@ -79,13 +81,13 @@ function makeTty() {
 function renderPanel(state: SettingsState = BASE) {
 	const tty = makeTty();
 	const onToggle = mock((_id: SettingsToggleId) => {});
-	const onOpenMemory = mock(() => {});
+	const onOpen = mock((_id: SettingsOpenId) => {});
 	const onClose = mock(() => {});
 	const instance = render(
 		React.createElement(SettingsPanel, {
 			state,
 			onToggle,
-			onOpenMemory,
+			onOpen,
 			onClose,
 		}),
 		{
@@ -102,35 +104,52 @@ function renderPanel(state: SettingsState = BASE) {
 	return {
 		instance,
 		press: tty.press,
+		lastFrame: tty.lastFrame,
 		ready,
 		selected,
 		onToggle,
-		onOpenMemory,
+		onOpen,
 		onClose,
 	};
 }
 
 describe("SettingsPanel interaction", () => {
 	it("opens the memory selector when Enter is pressed on the initial row", async () => {
-		const { instance, press, ready, onOpenMemory, onToggle } = renderPanel();
+		const { instance, press, ready, onOpen, onToggle } = renderPanel();
 		await ready();
 		press(ENTER);
-		await waitFor(() => onOpenMemory.mock.calls.length === 1);
+		await waitFor(() => onOpen.mock.calls.length === 1);
 		instance.unmount();
+		expect(onOpen).toHaveBeenCalledWith("memory");
+		expect(onToggle).not.toHaveBeenCalled();
+	});
+
+	it("opens the expert row from the second position", async () => {
+		const { instance, press, ready, selected, onOpen, onToggle } =
+			renderPanel();
+		await ready();
+		press(DOWN);
+		await selected("Expert");
+		press(ENTER);
+		await waitFor(() => onOpen.mock.calls.length === 1);
+		instance.unmount();
+		expect(onOpen).toHaveBeenCalledWith("expert");
 		expect(onToggle).not.toHaveBeenCalled();
 	});
 
 	it("moves down to the first toggle row and dispatches its id on Enter", async () => {
-		const { instance, press, ready, selected, onToggle, onOpenMemory } =
+		const { instance, press, ready, selected, onToggle, onOpen } =
 			renderPanel();
 		await ready();
+		press(DOWN);
+		await selected("Expert");
 		press(DOWN);
 		await selected("Verbose");
 		press(ENTER);
 		await waitFor(() => onToggle.mock.calls.length === 1);
 		instance.unmount();
 		expect(onToggle).toHaveBeenCalledWith("verbose");
-		expect(onOpenMemory).not.toHaveBeenCalled();
+		expect(onOpen).not.toHaveBeenCalled();
 	});
 
 	it("wraps to the last row when moving up from the first", async () => {
@@ -145,7 +164,7 @@ describe("SettingsPanel interaction", () => {
 	});
 
 	it("wraps back to the first row when moving down from the last", async () => {
-		const { instance, press, ready, selected, onOpenMemory, onToggle } =
+		const { instance, press, ready, selected, onOpen, onToggle } =
 			renderPanel();
 		await ready();
 		press(UP);
@@ -153,8 +172,9 @@ describe("SettingsPanel interaction", () => {
 		press(DOWN);
 		await selected("Memory");
 		press(ENTER);
-		await waitFor(() => onOpenMemory.mock.calls.length === 1);
+		await waitFor(() => onOpen.mock.calls.length === 1);
 		instance.unmount();
+		expect(onOpen).toHaveBeenCalledWith("memory");
 		expect(onToggle).not.toHaveBeenCalled();
 	});
 
@@ -164,6 +184,8 @@ describe("SettingsPanel interaction", () => {
 			lspPending: true,
 		});
 		await ready();
+		press(DOWN);
+		await selected("Expert");
 		press(DOWN);
 		await selected("Verbose");
 		press(DOWN);
@@ -175,6 +197,18 @@ describe("SettingsPanel interaction", () => {
 		await selected("Browser");
 		instance.unmount();
 		expect(onToggle).not.toHaveBeenCalled();
+	});
+
+	it("shows the execution model on the expert row", async () => {
+		const { instance, ready, lastFrame } = renderPanel({
+			...BASE,
+			expert: { enabled: true, model: "moonshot/kimi-k3" },
+		});
+		await ready();
+		const frame = lastFrame();
+		instance.unmount();
+		expect(frame).toContain("Expert");
+		expect(frame).toContain("moonshot/kimi-k3");
 	});
 
 	it("closes the panel when Esc is pressed", async () => {

--- a/tests/SettingsPanel.test.ts
+++ b/tests/SettingsPanel.test.ts
@@ -6,6 +6,7 @@ import {
 
 const BASE: SettingsState = {
 	memory: "auto",
+	expert: { enabled: false, model: null },
 	verbose: false,
 	notify: false,
 	lsp: false,
@@ -16,10 +17,11 @@ const BASE: SettingsState = {
 };
 
 describe("settingsRows", () => {
-	it("lists memory as the only opener followed by the toggle rows", () => {
+	it("lists the openers first, then the toggle rows", () => {
 		const rows = settingsRows(BASE);
 		expect(rows.map((row) => row.id)).toEqual([
 			"memory",
+			"expert",
 			"verbose",
 			"notify",
 			"lsp",
@@ -32,6 +34,26 @@ describe("settingsRows", () => {
 			label: "Memory",
 			value: "Auto",
 		});
+		expect(rows.find((row) => row.id === "expert")).toMatchObject({
+			kind: "open",
+			label: "Expert",
+			value: "Off",
+		});
+	});
+
+	it("shows the execution model on the expert row once it is on", () => {
+		const value = (expert: SettingsState["expert"]): string | undefined => {
+			const row = settingsRows({ ...BASE, expert }).find(
+				(entry) => entry.id === "expert",
+			);
+			return row?.kind === "open" ? row.value : undefined;
+		};
+		expect(value({ enabled: true, model: "moonshot/kimi-k3" })).toBe(
+			"moonshot/kimi-k3",
+		);
+		// A remembered pick with the switch off still reads as off.
+		expect(value({ enabled: false, model: "moonshot/kimi-k3" })).toBe("Off");
+		expect(value({ enabled: true, model: null })).toBe("Off");
 	});
 
 	it("reports on/off state for the toggle rows", () => {

--- a/tests/Store.test.ts
+++ b/tests/Store.test.ts
@@ -837,6 +837,43 @@ describe("Store reducer", () => {
 		expect(item.detail).toContain("Found the relevant files");
 	});
 
+	it("previews long Agent reports instead of emitting a raw slice", () => {
+		let state = initialState("gpt-test");
+		state = reduce(state, {
+			type: "tool:start",
+			toolCallId: "call_1",
+			name: "Agent",
+			inputSummary: "inspect",
+		});
+		const report = Array.from(
+			{ length: 60 },
+			(_, i) => `line ${i} ${"x".repeat(300)}`,
+		).join("\n");
+		state = reduce(state, {
+			type: "tool:result",
+			toolCallId: "call_1",
+			name: "Agent",
+			title: "Agent worker (3 rounds)",
+			agentOutput: {
+				mode: "worker",
+				status: "completed",
+				rounds: 3,
+				report,
+			},
+		});
+
+		const item = state.transcript[0];
+		if (item?.kind !== "tool") throw new Error("expected tool item");
+		const lines = (item.detail ?? "").split("\n");
+		// meta line + capped report lines + the "more lines" footer
+		expect(lines).toHaveLength(26);
+		expect(lines[0]).toContain("mode: worker");
+		expect(lines.at(-1)).toBe("… +36 more lines");
+		for (const line of lines.slice(1)) {
+			expect(line.length).toBeLessThanOrEqual(96);
+		}
+	});
+
 	it("tracks live child tool calls under running Agent rows", () => {
 		let state = initialState("gpt-test");
 		state = reduce(state, {

--- a/tests/SubAgentRunner.test.ts
+++ b/tests/SubAgentRunner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelRef } from "../src/config/defaults.ts";
 import { AgentTraceContext } from "../src/core/agent/AgentTraceStore.ts";
 import {
 	SubAgentRunner,
@@ -110,6 +111,65 @@ function runnerWith(client: BackboardClient, tools: Tool[]): SubAgentRunner {
 		toolFactory: () => tools,
 	});
 }
+
+describe("SubAgentRunner model override", () => {
+	it("resolves thinking and tool policy from the definition's model", async () => {
+		const pinned = { provider: "moonshot", model: "kimi-k3" };
+		const thinkingModels: ModelRef[] = [];
+		const toolGateModels: ModelRef[] = [];
+		const runner = new SubAgentRunner({
+			client: new CompletingClient(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async (model) => {
+				thinkingModels.push(model);
+				return undefined;
+			},
+			toolFactory: () => [new TestTool({ name: "Read", readOnly: true })],
+			isToolEnabled: (_name, model) => {
+				toolGateModels.push(model);
+				return true;
+			},
+		});
+
+		await runner.run({
+			prompt: "work",
+			depth: 1,
+			definition: { ...TEST_DEFINITION, model: pinned },
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(thinkingModels).toEqual([pinned]);
+		expect(toolGateModels.every((model) => model === pinned)).toBe(true);
+	});
+
+	it("falls back to the session model when the definition pins none", async () => {
+		const thinkingModels: ModelRef[] = [];
+		const runner = new SubAgentRunner({
+			client: new CompletingClient(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async (model) => {
+				thinkingModels.push(model);
+				return undefined;
+			},
+			toolFactory: () => [],
+		});
+
+		await runner.run({
+			prompt: "work",
+			depth: 1,
+			definition: TEST_DEFINITION,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(thinkingModels).toEqual([TEST_MODEL]);
+	});
+});
 
 describe("SubAgentRunner", () => {
 	it("returns only the sub-agent's final report and aggregates usage", async () => {

--- a/tests/SubAgentRunner.test.ts
+++ b/tests/SubAgentRunner.test.ts
@@ -7,6 +7,7 @@ import {
 	SubAgentRunner,
 	type SubAgentRunParams,
 } from "../src/core/agent/SubAgentRunner.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
 import { EventBus } from "../src/core/bus/EventBus.ts";
 import type { OpenAITool } from "../src/core/tools/schema.ts";
 import type { Tool } from "../src/core/tools/Tool.ts";
@@ -91,6 +92,14 @@ class RepeatingToolCallClient extends CompletingClient {
 	}
 }
 
+const TEST_DEFINITION: AgentDefinition = {
+	name: "worker",
+	description: "test worker",
+	mode: "worker",
+	systemPrompt: "you are a sub-agent",
+	source: "built-in",
+};
+
 function runnerWith(client: BackboardClient, tools: Tool[]): SubAgentRunner {
 	return new SubAgentRunner({
 		client,
@@ -98,7 +107,6 @@ function runnerWith(client: BackboardClient, tools: Tool[]): SubAgentRunner {
 		memory: "off",
 		memoryProfile: "code",
 		getThinking: async () => undefined,
-		systemPrompt: "you are a sub-agent",
 		toolFactory: () => tools,
 	});
 }
@@ -113,6 +121,7 @@ describe("SubAgentRunner", () => {
 		const result = await runner.run({
 			prompt: "summarize the module\n\nReturn one sentence.",
 			depth: 1,
+			definition: TEST_DEFINITION,
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
 		});
@@ -156,6 +165,7 @@ describe("SubAgentRunner", () => {
 		await runner.run({
 			prompt: "x",
 			depth: 2,
+			definition: TEST_DEFINITION,
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
 		});
@@ -170,6 +180,7 @@ describe("SubAgentRunner", () => {
 		await runner.run({
 			prompt: "x",
 			depth: 1,
+			definition: TEST_DEFINITION,
 			parentCwd: process.cwd(),
 			parentSignal: controller.signal,
 		});
@@ -189,6 +200,7 @@ describe("SubAgentRunner", () => {
 		const result = await runner.run({
 			prompt: "keep using tools",
 			depth: 1,
+			definition: TEST_DEFINITION,
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
 		});
@@ -208,6 +220,7 @@ describe("SubAgentRunner", () => {
 			await runner.run({
 				prompt: "summarize",
 				depth: 1,
+				definition: TEST_DEFINITION,
 				parentCwd: dir,
 				parentSignal: new AbortController().signal,
 				trace: {
@@ -272,6 +285,7 @@ describe("SubAgentRunner", () => {
 		const result = await runner.run({
 			prompt: "track child work",
 			depth: 1,
+			definition: TEST_DEFINITION,
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
 			parentBus,
@@ -303,6 +317,7 @@ describe("SubAgentRunner", () => {
 			{
 				prompt: "x",
 				depth: 1,
+				definition: TEST_DEFINITION,
 				parentCwd: process.cwd(),
 				parentSignal: controller.signal,
 				parentBus,

--- a/tests/SubAgentRunner.test.ts
+++ b/tests/SubAgentRunner.test.ts
@@ -132,8 +132,12 @@ describe("SubAgentRunner", () => {
 		expect(client.messageRequests[0]?.content).toBe(
 			"summarize the module\n\nReturn one sentence.",
 		);
-		expect(client.messageRequests[0]?.system_prompt).toBe(
+		expect(client.messageRequests[0]?.system_prompt).toStartWith(
 			"you are a sub-agent",
+		);
+		// The report contract is appended so an agent file cannot drop it.
+		expect(client.messageRequests[0]?.system_prompt).toContain(
+			"the parent receives that message and nothing else",
 		);
 	});
 

--- a/tests/agentDiscovery.test.ts
+++ b/tests/agentDiscovery.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentCatalog } from "../src/core/agents/AgentCatalog.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { discoverAgents } from "../src/core/agents/discovery.ts";
+import { parseAgentFromMarkdown } from "../src/core/agents/parse.ts";
+
+async function withProject(
+	files: Record<string, string>,
+	run: (cwd: string) => Promise<void>,
+): Promise<void> {
+	const dir = await mkdtemp(join(tmpdir(), "cli-agents-"));
+	try {
+		// discoverAgents resolves the repo root via .git, so mark this dir as one.
+		await mkdir(join(dir, ".git"), { recursive: true });
+		const agentsDir = join(dir, ".backboard", "agents");
+		await mkdir(agentsDir, { recursive: true });
+		for (const [name, content] of Object.entries(files)) {
+			await writeFile(join(agentsDir, name), content, "utf8");
+		}
+		await run(dir);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+const RESEARCHER = `---
+name: researcher
+description: Deep-dives one question, read-only.
+tools: [read, grep, glob]
+maxRounds: 30
+timeoutMs: 300000
+background: true
+---
+You are a research sub-agent. Never modify files.`;
+
+describe("parseAgentFromMarkdown", () => {
+	it("parses frontmatter and uses the body as the system prompt", () => {
+		const result = parseAgentFromMarkdown(
+			RESEARCHER,
+			"researcher",
+			"/agents/researcher.md",
+			"project",
+		);
+		expect(result.warning).toBeUndefined();
+		expect(result.agent).toMatchObject({
+			name: "researcher",
+			mode: "worker",
+			tools: ["read", "grep", "glob"],
+			maxRounds: 30,
+			timeoutMs: 300_000,
+			background: true,
+			source: "project",
+		});
+		expect(result.agent?.systemPrompt).toBe(
+			"You are a research sub-agent. Never modify files.",
+		);
+	});
+
+	it("names the rule when a capitalized filename is rejected", () => {
+		const result = parseAgentFromMarkdown(
+			"---\ndescription: d\n---\nbody",
+			"Researcher",
+			"/agents/Researcher.md",
+			"project",
+		);
+		expect(result.agent).toBeUndefined();
+		expect(result.warning).toContain("'Researcher'");
+		expect(result.warning).toContain("lowercase");
+		expect(result.warning).toContain("'name:' in frontmatter");
+	});
+
+	it("lets frontmatter name rescue a capitalized filename", () => {
+		const result = parseAgentFromMarkdown(
+			"---\nname: researcher\ndescription: d\n---\nbody",
+			"Researcher",
+			"/agents/Researcher.md",
+			"project",
+		);
+		expect(result.agent?.name).toBe("researcher");
+	});
+
+	it("falls back to the filename when name is omitted", () => {
+		const result = parseAgentFromMarkdown(
+			"---\ndescription: d\n---\nbody",
+			"reviewer",
+			"/agents/reviewer.md",
+			"user",
+		);
+		expect(result.agent?.name).toBe("reviewer");
+	});
+
+	it("resolves provider-qualified models and treats inherit as unset", () => {
+		const qualified = parseAgentFromMarkdown(
+			"---\ndescription: d\nmodel: anthropic/claude-opus-5\n---\nbody",
+			"a",
+			"/a.md",
+			"project",
+		);
+		expect(qualified.agent?.model).toEqual({
+			provider: "anthropic",
+			model: "claude-opus-5",
+		});
+
+		const inherited = parseAgentFromMarkdown(
+			"---\ndescription: d\nmodel: inherit\n---\nbody",
+			"a",
+			"/a.md",
+			"project",
+		);
+		expect(inherited.agent?.model).toBeUndefined();
+	});
+
+	it.each([
+		["missing frontmatter", "no frontmatter here", "missing YAML frontmatter"],
+		["missing description", "---\nname: a\n---\nbody", "missing description"],
+		["empty body", "---\ndescription: d\n---\n", "missing system prompt body"],
+		["bad mode", "---\ndescription: d\nmode: swarm\n---\nbody", "mode must be"],
+		[
+			"bad name",
+			"---\nname: Bad Name\ndescription: d\n---\nbody",
+			"use lowercase letters, digits, and hyphens only",
+		],
+		[
+			"bad tools",
+			"---\ndescription: d\ntools: read\n---\nbody",
+			"tools must be a list",
+		],
+		[
+			"bad maxRounds",
+			"---\ndescription: d\nmaxRounds: 0\n---\nbody",
+			"maxRounds must be a positive integer",
+		],
+	])("rejects %s", (_label, content, expected) => {
+		const result = parseAgentFromMarkdown(content, "a", "/a.md", "project");
+		expect(result.agent).toBeUndefined();
+		expect(result.warning).toContain(expected);
+	});
+});
+
+describe("AgentCatalog", () => {
+	const agent = (name: string, description: string): AgentDefinition => ({
+		name,
+		description,
+		mode: "worker",
+		systemPrompt: "p",
+		source: "project",
+	});
+
+	it("keeps the first definition for a repeated name", () => {
+		const catalog = new AgentCatalog([
+			agent("dup", "project wins"),
+			agent("dup", "user loses"),
+			agent("other", "kept"),
+		]);
+		expect(catalog.get("dup")?.description).toBe("project wins");
+		expect(catalog.names).toEqual(["dup", "other"]);
+	});
+
+	it("keeps lookups, names, and the prompt catalog consistent", () => {
+		const catalog = new AgentCatalog([
+			agent("dup", "first"),
+			agent("dup", "second"),
+		]);
+		expect(catalog.agents).toHaveLength(1);
+		expect(catalog.promptCatalog).toBe("- `dup`: first");
+		expect(catalog.names.map((n) => catalog.get(n)?.description)).toEqual([
+			"first",
+		]);
+	});
+});
+
+describe("discoverAgents", () => {
+	it("always exposes the built-in worker and rlm agents", async () => {
+		const catalog = await discoverAgents({
+			cwd: process.cwd(),
+			includeProjectAgents: false,
+			includeUserAgents: false,
+		});
+		expect(catalog.names).toEqual(["worker", "rlm"]);
+		expect(catalog.get("worker")?.mode).toBe("worker");
+		expect(catalog.get("rlm")?.mode).toBe("rlm");
+	});
+
+	it("loads project agents ahead of built-ins and skips invalid files", async () => {
+		await withProject(
+			{ "researcher.md": RESEARCHER, "broken.md": "not an agent" },
+			async (cwd) => {
+				const catalog = await discoverAgents({
+					cwd,
+					includeUserAgents: false,
+				});
+				expect(catalog.names).toEqual(["researcher", "worker", "rlm"]);
+				expect(catalog.get("researcher")?.source).toBe("project");
+				expect(catalog.warnings.join("\n")).toContain("broken.md");
+			},
+		);
+	});
+
+	it("lets a project agent shadow a built-in of the same name", async () => {
+		await withProject(
+			{ "worker.md": "---\ndescription: custom\n---\nCustom worker prompt." },
+			async (cwd) => {
+				const catalog = await discoverAgents({
+					cwd,
+					includeUserAgents: false,
+				});
+				expect(catalog.names).toEqual(["worker", "rlm"]);
+				expect(catalog.get("worker")?.systemPrompt).toBe(
+					"Custom worker prompt.",
+				);
+				expect(catalog.get("worker")?.source).toBe("project");
+			},
+		);
+	});
+
+	it("renders a prompt catalog listing every agent", async () => {
+		await withProject({ "researcher.md": RESEARCHER }, async (cwd) => {
+			const catalog = await discoverAgents({ cwd, includeUserAgents: false });
+			expect(catalog.promptCatalog).toContain(
+				"- `researcher`: Deep-dives one question, read-only.",
+			);
+			expect(catalog.promptCatalog).toContain("- `worker`:");
+		});
+	});
+});

--- a/tests/agentDiscovery.test.ts
+++ b/tests/agentDiscovery.test.ts
@@ -114,6 +114,35 @@ describe("parseAgentFromMarkdown", () => {
 	});
 
 	it.each([
+		["/", "model: /"],
+		["missing model", "model: anthropic/"],
+		["missing provider", "model: /claude-opus-5"],
+		["whitespace parts", 'model: " / "'],
+	])("rejects a malformed model reference (%s)", (_label, line) => {
+		const result = parseAgentFromMarkdown(
+			`---\ndescription: d\n${line}\n---\nbody`,
+			"a",
+			"/a.md",
+			"project",
+		);
+		expect(result.agent).toBeUndefined();
+		expect(result.warning).toContain("invalid model");
+	});
+
+	it("trims whitespace around qualified model parts", () => {
+		const result = parseAgentFromMarkdown(
+			'---\ndescription: d\nmodel: " anthropic / claude-opus-5 "\n---\nbody',
+			"a",
+			"/a.md",
+			"project",
+		);
+		expect(result.agent?.model).toEqual({
+			provider: "anthropic",
+			model: "claude-opus-5",
+		});
+	});
+
+	it.each([
 		["missing frontmatter", "no frontmatter here", "missing YAML frontmatter"],
 		["missing description", "---\nname: a\n---\nbody", "missing description"],
 		["empty body", "---\ndescription: d\n---\n", "missing system prompt body"],

--- a/tests/agentDiscovery.test.ts
+++ b/tests/agentDiscovery.test.ts
@@ -129,6 +129,23 @@ describe("parseAgentFromMarkdown", () => {
 		expect(result.warning).toContain("invalid model");
 	});
 
+	it.each([
+		["number", "model: 123"],
+		["null", "model: null"],
+		["empty string", 'model: ""'],
+		["mapping", "model:\n  provider: anthropic"],
+		["sequence", "model: [anthropic/claude-opus-5]"],
+	])("rejects an explicit non-string model value (%s)", (_label, line) => {
+		const result = parseAgentFromMarkdown(
+			`---\ndescription: d\n${line}\n---\nbody`,
+			"a",
+			"/a.md",
+			"project",
+		);
+		expect(result.agent).toBeUndefined();
+		expect(result.warning).toContain("invalid model");
+	});
+
 	it("trims whitespace around qualified model parts", () => {
 		const result = parseAgentFromMarkdown(
 			'---\ndescription: d\nmodel: " anthropic / claude-opus-5 "\n---\nbody',

--- a/tests/agentToolRegistry.test.ts
+++ b/tests/agentToolRegistry.test.ts
@@ -49,10 +49,12 @@ function makeTool(
 	tool: AgentTool;
 	workerCalls: SubAgentRunParams[];
 	rlmCalls: RLMRunParams[];
+	rlmDefinitions: AgentDefinition[];
 	release: () => void;
 } {
 	const workerCalls: SubAgentRunParams[] = [];
 	const rlmCalls: RLMRunParams[] = [];
+	const rlmDefinitions: AgentDefinition[] = [];
 	let release!: () => void;
 	const gate = new Promise<void>((resolve) => {
 		release = resolve;
@@ -71,8 +73,9 @@ function makeTool(
 				};
 			},
 		},
-		createRLMLoop: () => ({
+		createRLMLoop: (definition) => ({
 			run: async (params) => {
+				rlmDefinitions.push(definition);
 				rlmCalls.push(params);
 				return {
 					report: "rlm report",
@@ -87,7 +90,7 @@ function makeTool(
 		maxDepth: 2,
 		maxConcurrent,
 	});
-	return { tool, workerCalls, rlmCalls, release };
+	return { tool, workerCalls, rlmCalls, rlmDefinitions, release };
 }
 
 describe("AgentTool registry dispatch", () => {
@@ -111,6 +114,25 @@ describe("AgentTool registry dispatch", () => {
 		expect(result.data.mode).toBe("rlm");
 		expect(workerCalls).toHaveLength(0);
 		expect(rlmCalls[0]?.timeoutMs).toBe(60_000);
+	});
+
+	it("hands the rlm factory the definition so it can apply model and rounds", async () => {
+		const { tool, rlmDefinitions, release } = makeTool([
+			{
+				...ANALYST,
+				model: { provider: "anthropic", model: "claude-opus-5" },
+				maxRounds: 3,
+			},
+		]);
+		release();
+		await tool.execute({ prompt: "crunch", subagent_type: "analyst" }, ctx());
+
+		expect(rlmDefinitions[0]?.systemPrompt).toBe("You analyze.");
+		expect(rlmDefinitions[0]?.model).toEqual({
+			provider: "anthropic",
+			model: "claude-opus-5",
+		});
+		expect(rlmDefinitions[0]?.maxRounds).toBe(3);
 	});
 
 	it("lets an explicit timeout_ms override the definition budget", async () => {

--- a/tests/agentToolRegistry.test.ts
+++ b/tests/agentToolRegistry.test.ts
@@ -127,23 +127,10 @@ describe("AgentTool registry dispatch", () => {
 		expect(rlmCalls[0]?.timeoutMs).toBe(5_000);
 	});
 
-	it("refuses a permit pool smaller than the nesting depth", () => {
-		expect(() => makeTool([RESEARCHER], 1)).toThrow(
-			"maxConcurrent (1) >= maxDepth (2)",
-		);
-	});
-
-	it("ships defaults that satisfy the no-deadlock invariant", () => {
-		expect(DEFAULT_AGENT_MAX_CONCURRENT).toBeGreaterThanOrEqual(
-			DEFAULT_AGENT_MAX_DEPTH,
-		);
-	});
-
-	it("lets a full-depth chain finish when permits exactly match depth", async () => {
-		// One permit per level is the tight case the guard allows: the parent
-		// holds a permit while awaiting the child, so the pool must not starve.
+	it("does not deadlock when parallel chains all spawn nested agents", async () => {
 		const catalog = new AgentCatalog([...BUILT_IN_AGENTS]);
 		let tool!: AgentTool;
+		let nested = 0;
 		tool = new AgentTool({
 			runner: {
 				run: async ({ depth }) => {
@@ -152,9 +139,10 @@ describe("AgentTool registry dispatch", () => {
 							{ prompt: "nested" },
 							{ ...baseCtx(), agentDepth: depth },
 						);
+						nested++;
 					}
 					return {
-						report: `depth ${depth}`,
+						report: "r",
 						status: "completed" as const,
 						usage: {},
 						toolRounds: 1,
@@ -168,11 +156,19 @@ describe("AgentTool registry dispatch", () => {
 			}),
 			getCatalog: () => catalog,
 			maxDepth: 2,
-			maxConcurrent: 2,
+			maxConcurrent: 4,
 		});
 
-		const result = await tool.execute({ prompt: "root" }, baseCtx());
-		expect(result.data.report).toBe("depth 1");
+		const chains = Array.from({ length: 4 }, () =>
+			tool.execute({ prompt: "top" }, baseCtx()),
+		);
+		const outcome = await Promise.race([
+			Promise.all(chains).then(() => "completed"),
+			new Promise((resolve) => setTimeout(() => resolve("deadlock"), 1_000)),
+		]);
+
+		expect(outcome).toBe("completed");
+		expect(nested).toBe(4);
 	});
 
 	it("caps concurrent runs and queues the overflow", async () => {

--- a/tests/agentToolRegistry.test.ts
+++ b/tests/agentToolRegistry.test.ts
@@ -7,10 +7,6 @@ import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
 import { EventBus } from "../src/core/bus/EventBus.ts";
 import type { ToolContext } from "../src/core/tools/ToolContext.ts";
 import { AgentTool } from "../src/tools/AgentTool.tsx";
-import {
-	DEFAULT_AGENT_MAX_CONCURRENT,
-	DEFAULT_AGENT_MAX_DEPTH,
-} from "../src/tools/AgentToolConstants.ts";
 
 function baseCtx(): ToolContext {
 	return {

--- a/tests/agentToolRegistry.test.ts
+++ b/tests/agentToolRegistry.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "bun:test";
+import type { RLMRunParams } from "../src/core/agent/rlm/RLMLoop.ts";
+import type { SubAgentRunParams } from "../src/core/agent/SubAgentRunner.ts";
+import { AgentCatalog } from "../src/core/agents/AgentCatalog.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
+import { EventBus } from "../src/core/bus/EventBus.ts";
+import type { ToolContext } from "../src/core/tools/ToolContext.ts";
+import { AgentTool } from "../src/tools/AgentTool.tsx";
+import {
+	DEFAULT_AGENT_MAX_CONCURRENT,
+	DEFAULT_AGENT_MAX_DEPTH,
+} from "../src/tools/AgentToolConstants.ts";
+
+function baseCtx(): ToolContext {
+	return {
+		sessionId: "s",
+		cwd: process.cwd(),
+		bus: new EventBus(),
+		signal: new AbortController().signal,
+		askUser: async () => "",
+		agentDepth: 0,
+	};
+}
+
+const ctx = baseCtx;
+
+const RESEARCHER: AgentDefinition = {
+	name: "researcher",
+	description: "Reads only.",
+	mode: "worker",
+	systemPrompt: "You research.",
+	tools: ["read", "grep"],
+	model: { provider: "anthropic", model: "claude-opus-5" },
+	maxRounds: 30,
+	timeoutMs: 300_000,
+	source: "project",
+};
+
+const ANALYST: AgentDefinition = {
+	name: "analyst",
+	description: "Crunches data in a REPL.",
+	mode: "rlm",
+	systemPrompt: "You analyze.",
+	timeoutMs: 60_000,
+	source: "project",
+};
+
+function makeTool(
+	agents: AgentDefinition[],
+	maxConcurrent = 8,
+): {
+	tool: AgentTool;
+	workerCalls: SubAgentRunParams[];
+	rlmCalls: RLMRunParams[];
+	release: () => void;
+} {
+	const workerCalls: SubAgentRunParams[] = [];
+	const rlmCalls: RLMRunParams[] = [];
+	let release!: () => void;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+
+	const tool = new AgentTool({
+		runner: {
+			run: async (params) => {
+				workerCalls.push(params);
+				await gate;
+				return {
+					report: "report",
+					status: "completed" as const,
+					usage: {},
+					toolRounds: 1,
+				};
+			},
+		},
+		createRLMLoop: () => ({
+			run: async (params) => {
+				rlmCalls.push(params);
+				return {
+					report: "rlm report",
+					status: "completed" as const,
+					usage: {},
+					rounds: 1,
+					trajectory: [],
+				};
+			},
+		}),
+		getCatalog: () => new AgentCatalog([...agents, ...BUILT_IN_AGENTS]),
+		maxDepth: 2,
+		maxConcurrent,
+	});
+	return { tool, workerCalls, rlmCalls, release };
+}
+
+describe("AgentTool registry dispatch", () => {
+	it("passes the resolved definition through to the runner", async () => {
+		const { tool, workerCalls, release } = makeTool([RESEARCHER]);
+		release();
+		await tool.execute(
+			{ prompt: "find callers", subagent_type: "researcher" },
+			ctx(),
+		);
+		expect(workerCalls[0]?.definition).toEqual(RESEARCHER);
+	});
+
+	it("routes rlm-mode definitions to the REPL loop", async () => {
+		const { tool, rlmCalls, workerCalls, release } = makeTool([ANALYST]);
+		release();
+		const result = await tool.execute(
+			{ prompt: "crunch", subagent_type: "analyst" },
+			ctx(),
+		);
+		expect(result.data.mode).toBe("rlm");
+		expect(workerCalls).toHaveLength(0);
+		expect(rlmCalls[0]?.timeoutMs).toBe(60_000);
+	});
+
+	it("lets an explicit timeout_ms override the definition budget", async () => {
+		const { tool, rlmCalls, release } = makeTool([ANALYST]);
+		release();
+		await tool.execute(
+			{ prompt: "crunch", subagent_type: "analyst", timeout_ms: 5_000 },
+			ctx(),
+		);
+		expect(rlmCalls[0]?.timeoutMs).toBe(5_000);
+	});
+
+	it("refuses a permit pool smaller than the nesting depth", () => {
+		expect(() => makeTool([RESEARCHER], 1)).toThrow(
+			"maxConcurrent (1) >= maxDepth (2)",
+		);
+	});
+
+	it("ships defaults that satisfy the no-deadlock invariant", () => {
+		expect(DEFAULT_AGENT_MAX_CONCURRENT).toBeGreaterThanOrEqual(
+			DEFAULT_AGENT_MAX_DEPTH,
+		);
+	});
+
+	it("lets a full-depth chain finish when permits exactly match depth", async () => {
+		// One permit per level is the tight case the guard allows: the parent
+		// holds a permit while awaiting the child, so the pool must not starve.
+		const catalog = new AgentCatalog([...BUILT_IN_AGENTS]);
+		let tool!: AgentTool;
+		tool = new AgentTool({
+			runner: {
+				run: async ({ depth }) => {
+					if (depth < 2) {
+						await tool.execute(
+							{ prompt: "nested" },
+							{ ...baseCtx(), agentDepth: depth },
+						);
+					}
+					return {
+						report: `depth ${depth}`,
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => catalog,
+			maxDepth: 2,
+			maxConcurrent: 2,
+		});
+
+		const result = await tool.execute({ prompt: "root" }, baseCtx());
+		expect(result.data.report).toBe("depth 1");
+	});
+
+	it("caps concurrent runs and queues the overflow", async () => {
+		const { tool, workerCalls, release } = makeTool([RESEARCHER], 2);
+		const runs = [1, 2, 3, 4].map(() =>
+			tool.execute({ prompt: "go", subagent_type: "researcher" }, ctx()),
+		);
+
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(workerCalls).toHaveLength(2);
+
+		release();
+		await Promise.all(runs);
+		expect(workerCalls).toHaveLength(4);
+	});
+});

--- a/tests/backgroundAgentFlow.test.ts
+++ b/tests/backgroundAgentFlow.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "bun:test";
+import { Config } from "../src/config/Config.ts";
+import { AgentController } from "../src/core/agent/AgentController.ts";
+import { BackgroundAgentSupervisor } from "../src/core/agent/BackgroundAgentSupervisor.ts";
+import { AgentCatalog } from "../src/core/agents/AgentCatalog.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
+import { EventBus } from "../src/core/bus/EventBus.ts";
+import type { AgentEvent } from "../src/core/bus/events.ts";
+import { emptyRuleSet } from "../src/core/permissions/PermissionRules.ts";
+import type { PermissionContext } from "../src/core/permissions/types.ts";
+import { Session } from "../src/core/session/Session.ts";
+import { SkillController } from "../src/core/skills/SkillController.ts";
+import { ToolRegistry } from "../src/core/tools/ToolRegistry.ts";
+import type { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
+import type {
+	AssistantInfo,
+	ProviderEvent,
+	SendMessageRequest,
+} from "../src/providers/backboard/types.ts";
+import { initialState } from "../src/state/AppState.ts";
+import { reduce } from "../src/state/Store.ts";
+import { AgentTool } from "../src/tools/AgentTool.tsx";
+
+const env = { apiKey: "k", apiUrl: "https://example.test/api" };
+const PERMISSIONS: PermissionContext = {
+	mode: "bypass",
+	rules: emptyRuleSet(),
+	interactive: false,
+};
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const WATCHER: AgentDefinition = {
+	name: "watcher",
+	description: "Runs a long check in the background.",
+	mode: "worker",
+	systemPrompt: "You run checks.",
+	background: true,
+	source: "project",
+};
+
+/**
+ * Answers the first user turn by calling Agent(watcher), then answers every
+ * later turn (including the injected background report) with plain text.
+ */
+class ScriptedClient {
+	readonly capabilities = { assistants: true, threads: true, memory: true };
+	readonly prompts: string[] = [];
+	private turn = 0;
+
+	async listAssistants(): Promise<AssistantInfo[]> {
+		return [];
+	}
+	async createAssistant(): Promise<AssistantInfo> {
+		return { assistant_id: "asst_1", name: "test" };
+	}
+	sourceForThread(): "backboard" {
+		return "backboard";
+	}
+
+	async *runMessage(req: SendMessageRequest): AsyncIterable<ProviderEvent> {
+		this.prompts.push(req.content ?? "");
+		this.turn++;
+		yield { kind: "thread", threadId: "thr_1" };
+		if (this.turn === 1) {
+			yield {
+				kind: "requires_action",
+				runId: "run_1",
+				calls: [
+					{
+						id: "call_1",
+						name: "agent",
+						input: { subagent_type: "watcher", prompt: "run the checks" },
+					},
+				],
+			};
+			return;
+		}
+		yield { kind: "assistant_delta", text: `ack turn ${this.turn}` };
+		yield { kind: "completed" };
+	}
+
+	async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+		yield { kind: "assistant_delta", text: "launched, moving on" };
+		yield { kind: "completed" };
+	}
+}
+
+describe("background agent end-to-end", () => {
+	it("returns the turn immediately, then delivers the report as its own turn", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const events: AgentEvent[] = [];
+		bus.onAny((event) => events.push(event));
+		const session = new Session("sess_bg");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async () => {
+					await agentWork;
+					return {
+						report: "all 1414 checks passed",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 3,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		const client = new ScriptedClient();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		supervisor.setNotifier((report) => {
+			void controller.submit(report, {
+				emitUserMessage: false,
+				priority: "later",
+			});
+		});
+
+		// 1. The spawning turn finishes without waiting for the agent.
+		const status = await controller.submit("run the checks in the background");
+		expect(status).toBe("completed");
+		expect(supervisor.active).toHaveLength(1);
+		expect(client.prompts).toHaveLength(1);
+
+		// 2. The UI shows it as running while the turn is already over.
+		let state = initialState("test");
+		for (const event of events) state = reduce(state, event);
+		expect(state.backgroundAgents.map((run) => run.agent)).toEqual(["watcher"]);
+		expect(state.status).not.toBe("running");
+
+		// 3. When it finishes, its report drives a fresh turn on its own.
+		released();
+		await sleep(120);
+
+		expect(supervisor.active).toHaveLength(0);
+		expect(client.prompts).toHaveLength(2);
+		expect(client.prompts[1]).toContain("all 1414 checks passed");
+		expect(client.prompts[1]).toContain('agent="watcher"');
+		expect(client.prompts[1]).toContain("may have changed");
+
+		// 4. The status row clears once it reports.
+		state = initialState("test");
+		for (const event of events) state = reduce(state, event);
+		expect(state.backgroundAgents).toEqual([]);
+	});
+
+	it("keeps background work alive when the foreground turn is cancelled", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg2");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let sawAbort: boolean | undefined;
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async ({ parentSignal }) => {
+					await agentWork;
+					sawAbort = parentSignal.aborted;
+					return {
+						report: "survived",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		const client = new ScriptedClient();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		await controller.submit("start it");
+		expect(supervisor.active).toHaveLength(1);
+
+		// ESC on the main thread must not reach the background agent.
+		controller.cancel();
+		released();
+		await sleep(120);
+
+		expect(sawAbort).toBe(false);
+		expect(reports).toHaveLength(1);
+		expect(reports[0]).toContain("survived");
+	});
+});

--- a/tests/backgroundAgentFlow.test.ts
+++ b/tests/backgroundAgentFlow.test.ts
@@ -480,6 +480,49 @@ describe("background agent end-to-end", () => {
 		expect(client.prompts).toEqual(["start it"]);
 	});
 
+	it("waits for an outgoing turn before replacement storage is activated", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg8");
+		const order: string[] = [];
+
+		// Commits regardless of its signal: cancellation only asks it to stop,
+		// so rotating storage now would let it write against the new roots.
+		const client = new (class extends ScriptedClient {
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "thr_1" };
+				await sleep(60);
+				order.push("turn committed");
+				yield { kind: "assistant_delta", text: "done" };
+				yield { kind: "completed" };
+			}
+		})();
+
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+		});
+
+		void controller.submit("start a stubborn turn");
+		await sleep(10);
+		expect(controller.hasActiveWork).toBe(true);
+
+		await startNewSession({
+			detach: () => controller.beginSessionReplacement(),
+			activate: async () => {
+				order.push("activate");
+			},
+			resetThread: () => controller.newThread(),
+		});
+
+		expect(order).toEqual(["turn committed", "activate"]);
+	});
+
 	it("caps the shutdown wait when a turn ignores its abort signal", async () => {
 		const config = new Config({ env, argv: [] });
 		const bus = new EventBus();

--- a/tests/backgroundAgentFlow.test.ts
+++ b/tests/backgroundAgentFlow.test.ts
@@ -22,6 +22,7 @@ import type {
 import { initialState } from "../src/state/AppState.ts";
 import { reduce } from "../src/state/Store.ts";
 import { AgentTool } from "../src/tools/AgentTool.tsx";
+import { startNewSession } from "../src/ui/utils/startNewSession.ts";
 
 const env = { apiKey: "k", apiUrl: "https://example.test/api" };
 const PERMISSIONS: PermissionContext = {
@@ -400,5 +401,222 @@ describe("background agent end-to-end", () => {
 				.map((message) => (message.role === "tool" ? "" : message.text))
 				.join("\n"),
 		).not.toContain("stale report processed");
+	});
+	it("stops background work before replacement storage is activated", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg5");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async () => {
+					await agentWork;
+					return {
+						report: "report for the outgoing session",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		const client = new ScriptedClient();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => {
+			reports.push(report);
+			void controller.submit(report, {
+				emitUserMessage: false,
+				priority: "later",
+			});
+		});
+
+		await controller.submit("start it");
+		expect(supervisor.active).toHaveLength(1);
+
+		// The run finishes inside the activation window, while checkpoint and
+		// event-log roots are being rotated onto the replacement session.
+		let rotated = false;
+		await startNewSession({
+			detach: () => controller.beginSessionReplacement(),
+			activate: async () => {
+				released();
+				await sleep(50);
+				rotated = true;
+			},
+			resetThread: () => controller.newThread(),
+		});
+		await sleep(50);
+
+		expect(rotated).toBe(true);
+		expect(supervisor.active).toHaveLength(0);
+		expect(reports).toEqual([]);
+		// No stale turn ran against the replacement session.
+		expect(client.prompts).toEqual(["start it"]);
+	});
+
+	it("caps the shutdown wait when a turn ignores its abort signal", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg7");
+
+		// A stream that never returns and never checks its signal.
+		const client = new (class extends ScriptedClient {
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "thr_1" };
+				await new Promise<void>(() => {});
+			}
+		})();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+		});
+
+		void controller.submit("wedge the turn");
+		await sleep(20);
+		expect(controller.hasActiveWork).toBe(true);
+
+		controller.cancel({ clearQueue: true });
+		const started = Date.now();
+		await controller.settle(50);
+
+		expect(Date.now() - started).toBeLessThan(1_000);
+		expect(controller.hasActiveWork).toBe(true);
+	});
+
+	it("cancels and awaits a report turn already underway when disposing", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg6");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async () => {
+					await agentWork;
+					return {
+						report: "late report",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		let releaseReport!: () => void;
+		const reportStream = new Promise<void>((resolve) => {
+			releaseReport = resolve;
+		});
+		const client = new (class extends ScriptedClient {
+			private turns = 0;
+			override async *runMessage(
+				req: SendMessageRequest,
+				options?: { signal?: AbortSignal },
+			): AsyncIterable<ProviderEvent> {
+				this.prompts.push(req.content ?? "");
+				this.turns++;
+				yield { kind: "thread", threadId: "thr_1" };
+				if (this.turns === 1) {
+					yield {
+						kind: "requires_action",
+						runId: "run_1",
+						calls: [
+							{
+								id: "call_1",
+								name: "agent",
+								input: { subagent_type: "watcher", prompt: "run the checks" },
+							},
+						],
+					};
+					return;
+				}
+				await reportStream;
+				if (options?.signal?.aborted) throw new AbortError();
+				yield { kind: "assistant_delta", text: "late report processed" };
+				yield { kind: "completed" };
+			}
+		})();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		supervisor.setNotifier((report) => {
+			void controller.submit(report, {
+				emitUserMessage: false,
+				priority: "later",
+			});
+		});
+
+		await controller.submit("start it");
+		// The run finishes after the UI exits but before shutdown reaches the
+		// supervisor: its report turn is already underway.
+		released();
+		await sleep(50);
+		expect(client.prompts).toHaveLength(2);
+
+		const disposed = controller.dispose();
+		releaseReport();
+		await disposed;
+
+		// Shutdown must not return while a turn can still touch tools, logs,
+		// or checkpoints.
+		expect(controller.hasActiveWork).toBe(false);
+		expect(
+			session
+				.getMessages()
+				.map((message) => (message.role === "tool" ? "" : message.text))
+				.join("\n"),
+		).not.toContain("late report processed");
 	});
 });

--- a/tests/backgroundAgentFlow.test.ts
+++ b/tests/backgroundAgentFlow.test.ts
@@ -11,6 +11,7 @@ import { emptyRuleSet } from "../src/core/permissions/PermissionRules.ts";
 import type { PermissionContext } from "../src/core/permissions/types.ts";
 import { Session } from "../src/core/session/Session.ts";
 import { SkillController } from "../src/core/skills/SkillController.ts";
+import { AbortError } from "../src/core/tools/ToolAbort.ts";
 import { ToolRegistry } from "../src/core/tools/ToolRegistry.ts";
 import type { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
 import type {
@@ -291,5 +292,113 @@ describe("background agent end-to-end", () => {
 
 		expect(supervisor.active).toHaveLength(0);
 		expect(reports).toEqual([]);
+	});
+
+	it("cancels a report turn already underway when a session is resumed", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg4");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async () => {
+					await agentWork;
+					return {
+						report: "stale report processed",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		// The report turn's stream stalls until released and, like a real HTTP
+		// stream, honors the abort signal.
+		let releaseReport!: () => void;
+		const reportStream = new Promise<void>((resolve) => {
+			releaseReport = resolve;
+		});
+		const client = new (class extends ScriptedClient {
+			private turns = 0;
+			override async *runMessage(
+				req: SendMessageRequest,
+				options?: { signal?: AbortSignal },
+			): AsyncIterable<ProviderEvent> {
+				this.prompts.push(req.content ?? "");
+				this.turns++;
+				yield { kind: "thread", threadId: "thr_1" };
+				if (this.turns === 1) {
+					yield {
+						kind: "requires_action",
+						runId: "run_1",
+						calls: [
+							{
+								id: "call_1",
+								name: "agent",
+								input: { subagent_type: "watcher", prompt: "run the checks" },
+							},
+						],
+					};
+					return;
+				}
+				await reportStream;
+				if (options?.signal?.aborted) throw new AbortError();
+				yield { kind: "assistant_delta", text: "stale report processed" };
+				yield { kind: "completed" };
+			}
+		})();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		supervisor.setNotifier((report) => {
+			void controller.submit(report, {
+				emitUserMessage: false,
+				priority: "later",
+			});
+		});
+
+		await controller.submit("start it");
+		expect(supervisor.active).toHaveLength(1);
+
+		// The run finishes and its report turn starts before the resume.
+		released();
+		await sleep(50);
+		expect(client.prompts).toHaveLength(2);
+		expect(supervisor.active).toHaveLength(0);
+
+		controller.hydrateSession({ threadId: "thr_other", messages: [] });
+		releaseReport();
+		await sleep(50);
+
+		expect(session.threadId).toBe("thr_other");
+		expect(
+			session
+				.getMessages()
+				.map((message) => (message.role === "tool" ? "" : message.text))
+				.join("\n"),
+		).not.toContain("stale report processed");
 	});
 });

--- a/tests/backgroundAgentFlow.test.ts
+++ b/tests/backgroundAgentFlow.test.ts
@@ -233,4 +233,63 @@ describe("background agent end-to-end", () => {
 		expect(reports).toHaveLength(1);
 		expect(reports[0]).toContain("survived");
 	});
+
+	it("drops background reports when another session is resumed", async () => {
+		const config = new Config({ env, argv: [] });
+		const bus = new EventBus();
+		const session = new Session("sess_bg3");
+		const supervisor = new BackgroundAgentSupervisor(bus);
+
+		let released!: () => void;
+		const agentWork = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+
+		const agentTool = new AgentTool({
+			runner: {
+				run: async () => {
+					await agentWork;
+					return {
+						report: "report for the discarded conversation",
+						status: "completed" as const,
+						usage: {},
+						toolRounds: 1,
+					};
+				},
+			},
+			createRLMLoop: () => ({
+				run: async () => {
+					throw new Error("unused");
+				},
+			}),
+			getCatalog: () => new AgentCatalog([WATCHER, ...BUILT_IN_AGENTS]),
+			maxDepth: 2,
+			maxConcurrent: 8,
+			supervisor,
+		});
+
+		const client = new ScriptedClient();
+		const controller = new AgentController({
+			config,
+			bus,
+			session,
+			registry: new ToolRegistry([agentTool]),
+			client: client as unknown as BackboardClient,
+			skillController: new SkillController({ cwd: config.cwd, bus }),
+			permissions: PERMISSIONS,
+			backgroundSupervisor: supervisor,
+		});
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		await controller.submit("start it");
+		expect(supervisor.active).toHaveLength(1);
+
+		controller.hydrateSession({ threadId: "thr_other", messages: [] });
+		released();
+		await sleep(120);
+
+		expect(supervisor.active).toHaveLength(0);
+		expect(reports).toEqual([]);
+	});
 });

--- a/tests/backgroundAgents.test.ts
+++ b/tests/backgroundAgents.test.ts
@@ -12,6 +12,7 @@ import type { ToolContext } from "../src/core/tools/ToolContext.ts";
 import { initialState } from "../src/state/AppState.ts";
 import { reduce } from "../src/state/Store.ts";
 import { AgentTool } from "../src/tools/AgentTool.tsx";
+import { rootReducer } from "../src/ui/hooks/useAgent.ts";
 
 const sleep = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));
@@ -273,5 +274,27 @@ describe("background agents in AppState", () => {
 			run: { ...run, status: "completed", rounds: 3, finishedAt: Date.now() },
 		} satisfies AgentEvent);
 		expect(state.backgroundAgents).toEqual([]);
+	});
+
+	it("drops rows when the session is cleared or hydrated", () => {
+		const run = {
+			id: "bg_2",
+			agent: "watcher",
+			label: "watch the build",
+			status: "running" as const,
+			startedAt: Date.now(),
+			rounds: 0,
+		};
+		let state = initialState("gpt-test");
+		state = reduce(state, {
+			type: "agent:background_started",
+			run,
+		} satisfies AgentEvent);
+		expect(state.backgroundAgents).toHaveLength(1);
+
+		expect(rootReducer(state, { type: "clear" }).backgroundAgents).toEqual([]);
+		expect(
+			rootReducer(state, { type: "hydrate", messages: [] }).backgroundAgents,
+		).toEqual([]);
 	});
 });

--- a/tests/backgroundAgents.test.ts
+++ b/tests/backgroundAgents.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "bun:test";
+import {
+	BackgroundAgentSupervisor,
+	backgroundReportMessage,
+} from "../src/core/agent/BackgroundAgentSupervisor.ts";
+import { AgentCatalog } from "../src/core/agents/AgentCatalog.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
+import { EventBus } from "../src/core/bus/EventBus.ts";
+import type { AgentEvent } from "../src/core/bus/events.ts";
+import type { ToolContext } from "../src/core/tools/ToolContext.ts";
+import { initialState } from "../src/state/AppState.ts";
+import { reduce } from "../src/state/Store.ts";
+import { AgentTool } from "../src/tools/AgentTool.tsx";
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const BACKGROUND_AGENT: AgentDefinition = {
+	name: "watcher",
+	description: "Runs in the background.",
+	mode: "worker",
+	systemPrompt: "p",
+	background: true,
+	source: "project",
+};
+
+function ctx(agentDepth = 0): ToolContext {
+	return {
+		sessionId: "s",
+		cwd: process.cwd(),
+		bus: new EventBus(),
+		signal: new AbortController().signal,
+		askUser: async () => "",
+		agentDepth,
+	};
+}
+
+function makeTool(options: {
+	supervisor?: BackgroundAgentSupervisor;
+	onRun?: (signal: AbortSignal) => Promise<void>;
+}): { tool: AgentTool; depths: number[] } {
+	const depths: number[] = [];
+	const tool = new AgentTool({
+		runner: {
+			run: async ({ depth, parentSignal }) => {
+				depths.push(depth);
+				await options.onRun?.(parentSignal);
+				return {
+					report: "done",
+					status: "completed" as const,
+					usage: {},
+					toolRounds: 2,
+				};
+			},
+		},
+		createRLMLoop: () => ({
+			run: async () => {
+				throw new Error("unused");
+			},
+		}),
+		getCatalog: () => new AgentCatalog([BACKGROUND_AGENT, ...BUILT_IN_AGENTS]),
+		maxDepth: 2,
+		maxConcurrent: 4,
+		...(options.supervisor ? { supervisor: options.supervisor } : {}),
+	});
+	return { tool, depths };
+}
+
+describe("BackgroundAgentSupervisor", () => {
+	it("returns immediately and reports through the notifier", async () => {
+		const bus = new EventBus();
+		const supervisor = new BackgroundAgentSupervisor(bus);
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		const snapshot = supervisor.launch({
+			definition: BACKGROUND_AGENT,
+			prompt: "watch the build",
+			run: async () => {
+				await sleep(10);
+				return {
+					report: "build is green",
+					status: "completed" as const,
+					usage: {},
+					toolRounds: 4,
+				};
+			},
+		});
+
+		expect(snapshot.status).toBe("running");
+		expect(supervisor.active).toHaveLength(1);
+		expect(reports).toHaveLength(0);
+
+		await sleep(60);
+		expect(supervisor.active).toHaveLength(0);
+		expect(reports).toHaveLength(1);
+		expect(reports[0]).toContain("build is green");
+		expect(reports[0]).toContain('agent="watcher"');
+	});
+
+	it("does not link runs to the caller's signal", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const caller = new AbortController();
+		let sawAbort: boolean | undefined;
+		supervisor.launch({
+			definition: BACKGROUND_AGENT,
+			prompt: "keep going",
+			run: async (signal) => {
+				caller.abort();
+				await sleep(10);
+				sawAbort = signal.aborted;
+				return {
+					report: "r",
+					status: "completed" as const,
+					usage: {},
+					toolRounds: 1,
+				};
+			},
+		});
+		await sleep(60);
+		expect(sawAbort).toBe(false);
+	});
+
+	it("stays silent for runs it cancelled", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+		supervisor.launch({
+			definition: BACKGROUND_AGENT,
+			prompt: "long job",
+			run: async (signal) => {
+				while (!signal.aborted) await sleep(5);
+				return {
+					report: "partial",
+					status: "cancelled" as const,
+					usage: {},
+					toolRounds: 1,
+				};
+			},
+		});
+
+		await sleep(20);
+		supervisor.cancelAll();
+		await sleep(60);
+		expect(reports).toEqual([]);
+		expect(supervisor.active).toHaveLength(0);
+	});
+
+	it("still reports when the run throws", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+		supervisor.launch({
+			definition: BACKGROUND_AGENT,
+			prompt: "explode",
+			run: async () => {
+				throw new Error("kaboom");
+			},
+		});
+		await sleep(60);
+		expect(reports).toHaveLength(1);
+		expect(reports[0]).toContain("kaboom");
+		expect(reports[0]).toContain('status="failed"');
+	});
+
+	it("warns the parent that the workspace may have moved on", () => {
+		const message = backgroundReportMessage(
+			{
+				id: "bg_1",
+				agent: "watcher",
+				label: "l",
+				status: "completed",
+				startedAt: 0,
+				finishedAt: 90_000,
+				rounds: 3,
+			},
+			"findings",
+		);
+		expect(message).toContain('elapsed="90s"');
+		expect(message).toContain("may have changed");
+	});
+});
+
+describe("AgentTool background dispatch", () => {
+	it("hands a background definition to the supervisor and returns at once", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const { tool } = makeTool({ supervisor });
+
+		const result = await tool.execute(
+			{ prompt: "watch", subagent_type: "watcher" },
+			ctx(),
+		);
+
+		expect(result.data.status).toBe("launched");
+		expect(result.data.runId).toBeDefined();
+		expect(result.forLLM).toContain("do not wait for it");
+		await sleep(40);
+	});
+
+	it("runs inline when no supervisor is wired", async () => {
+		const { tool } = makeTool({});
+		const result = await tool.execute(
+			{ prompt: "watch", subagent_type: "watcher" },
+			ctx(),
+		);
+		expect(result.data.status).toBe("completed");
+	});
+
+	it("ignores the background flag for nested spawns", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const { tool } = makeTool({ supervisor });
+
+		// depth 1 in context => this spawn is depth 2, i.e. already nested.
+		const result = await tool.execute(
+			{ prompt: "watch", subagent_type: "watcher" },
+			ctx(1),
+		);
+		expect(result.data.status).toBe("completed");
+		expect(supervisor.active).toHaveLength(0);
+	});
+});
+
+describe("background agents in AppState", () => {
+	it("adds a row while running and drops it when finished", () => {
+		const run = {
+			id: "bg_1",
+			agent: "watcher",
+			label: "watch the build",
+			status: "running" as const,
+			startedAt: Date.now(),
+			rounds: 0,
+		};
+		let state = initialState("gpt-test");
+		state = reduce(state, {
+			type: "agent:background_started",
+			run,
+		} satisfies AgentEvent);
+		expect(state.backgroundAgents).toHaveLength(1);
+
+		state = reduce(state, {
+			type: "agent:background_finished",
+			run: { ...run, status: "completed", rounds: 3, finishedAt: Date.now() },
+		} satisfies AgentEvent);
+		expect(state.backgroundAgents).toEqual([]);
+	});
+});

--- a/tests/backgroundAgents.test.ts
+++ b/tests/backgroundAgents.test.ts
@@ -147,6 +147,36 @@ describe("BackgroundAgentSupervisor", () => {
 		expect(supervisor.active).toHaveLength(0);
 	});
 
+	it("stays silent once the notifier is disabled for shutdown", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		let release!: () => void;
+		const work = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		supervisor.launch({
+			definition: BACKGROUND_AGENT,
+			prompt: "finishes during teardown",
+			run: async () => {
+				await work;
+				return {
+					report: "too late",
+					status: "completed" as const,
+					usage: {},
+					toolRounds: 1,
+				};
+			},
+		});
+
+		supervisor.disableNotifier();
+		release();
+		await sleep(60);
+
+		expect(reports).toEqual([]);
+	});
+
 	it("still reports when the run throws", async () => {
 		const supervisor = new BackgroundAgentSupervisor(new EventBus());
 		const reports: string[] = [];

--- a/tests/backgroundAgents.test.ts
+++ b/tests/backgroundAgents.test.ts
@@ -329,9 +329,34 @@ describe("background agents in AppState", () => {
 		} satisfies AgentEvent);
 		expect(state.backgroundAgents).toHaveLength(1);
 
-		expect(rootReducer(state, { type: "clear" }).backgroundAgents).toEqual([]);
+		expect(
+			rootReducer(state, { type: "clear", scope: "session" }).backgroundAgents,
+		).toEqual([]);
 		expect(
 			rootReducer(state, { type: "hydrate", messages: [] }).backgroundAgents,
 		).toEqual([]);
+	});
+
+	it("keeps running rows through a transcript-only clear", () => {
+		const run = {
+			id: "bg_3",
+			agent: "watcher",
+			label: "watch the build",
+			status: "running" as const,
+			startedAt: Date.now(),
+			rounds: 0,
+		};
+		let state = initialState("gpt-test");
+		state = reduce(state, {
+			type: "agent:background_started",
+			run,
+		} satisfies AgentEvent);
+
+		const compacted = rootReducer(state, {
+			type: "clear",
+			scope: "transcript",
+		});
+		expect(compacted.transcript).toEqual([]);
+		expect(compacted.backgroundAgents).toHaveLength(1);
 	});
 });

--- a/tests/backgroundAgents.test.ts
+++ b/tests/backgroundAgents.test.ts
@@ -9,6 +9,7 @@ import { BUILT_IN_AGENTS } from "../src/core/agents/builtin.ts";
 import { EventBus } from "../src/core/bus/EventBus.ts";
 import type { AgentEvent } from "../src/core/bus/events.ts";
 import type { ToolContext } from "../src/core/tools/ToolContext.ts";
+import { toolStartEvent } from "../src/core/tools/ToolEventFactory.ts";
 import { initialState } from "../src/state/AppState.ts";
 import { reduce } from "../src/state/Store.ts";
 import { AgentTool } from "../src/tools/AgentTool.tsx";
@@ -40,6 +41,7 @@ function ctx(agentDepth = 0): ToolContext {
 function makeTool(options: {
 	supervisor?: BackgroundAgentSupervisor;
 	onRun?: (signal: AbortSignal) => Promise<void>;
+	agents?: AgentDefinition[];
 }): { tool: AgentTool; depths: number[] } {
 	const depths: number[] = [];
 	const tool = new AgentTool({
@@ -60,7 +62,12 @@ function makeTool(options: {
 				throw new Error("unused");
 			},
 		}),
-		getCatalog: () => new AgentCatalog([BACKGROUND_AGENT, ...BUILT_IN_AGENTS]),
+		getCatalog: () =>
+			new AgentCatalog([
+				BACKGROUND_AGENT,
+				...(options.agents ?? []),
+				...BUILT_IN_AGENTS,
+			]),
 		maxDepth: 2,
 		maxConcurrent: 4,
 		...(options.supervisor ? { supervisor: options.supervisor } : {}),
@@ -249,6 +256,36 @@ describe("AgentTool background dispatch", () => {
 		);
 		expect(result.data.status).toBe("completed");
 		expect(supervisor.active).toHaveLength(0);
+	});
+});
+
+describe("agent mode in tool start events", () => {
+	const RLM_AGENT: AgentDefinition = {
+		name: "analyst",
+		description: "Analyzes structured inputs.",
+		mode: "rlm",
+		systemPrompt: "p",
+		source: "project",
+	};
+
+	it("labels a custom rlm agent from its catalog definition", () => {
+		const { tool } = makeTool({ agents: [RLM_AGENT] });
+		const event = toolStartEvent(
+			{ id: "call_1", name: "agent", input: {} },
+			{ prompt: "p", subagent_type: "analyst" },
+			tool,
+		);
+		expect(event).toMatchObject({ type: "tool:start", agentMode: "rlm" });
+	});
+
+	it("keeps the worker fallback for unknown names", () => {
+		const { tool } = makeTool({});
+		const event = toolStartEvent(
+			{ id: "call_2", name: "agent", input: {} },
+			{ prompt: "p", subagent_type: "missing" },
+			tool,
+		);
+		expect(event).toMatchObject({ type: "tool:start", agentMode: "worker" });
 	});
 });
 

--- a/tests/createDefaultTools.test.ts
+++ b/tests/createDefaultTools.test.ts
@@ -118,6 +118,68 @@ describe("createDefaultTools", () => {
 		);
 	});
 
+	it("runs worker subagents on the expert model with the tools to implement", async () => {
+		const config = new Config({ env: TEST_BACKBOARD_ENV, argv: [] });
+		config.setExpertMode({
+			enabled: true,
+			model: { provider: "moonshot", model: "kimi-k3" },
+		});
+		const client = new FakeClient([
+			{ kind: "thread", threadId: "thr_worker" },
+			{ kind: "assistant_delta", text: "worker report" },
+			{ kind: "completed" },
+		]);
+		const tools = createDefaultTools({ client, config });
+		const agent = tools.find((t): t is AgentTool => t.name === "Agent");
+
+		if (!agent) throw new Error("expected Agent tool");
+		await agent.execute({ prompt: "implement" }, context());
+
+		const request = client.messageRequests[0];
+		expect(request?.llm_provider).toBe("moonshot");
+		expect(request?.model_name).toBe("kimi-k3");
+		// The parent lost these to expert mode; the worker must still have them.
+		expect(toolNames(request?.tools ?? [])).toContain("edit");
+		expect(toolNames(request?.tools ?? [])).toContain("write");
+		expect(toolNames(request?.tools ?? [])).toContain("execute");
+	});
+
+	it("keeps nested workers on the expert model too", async () => {
+		const config = new Config({ env: TEST_BACKBOARD_ENV, argv: [] });
+		config.setExpertMode({
+			enabled: true,
+			model: { provider: "moonshot", model: "kimi-k3" },
+		});
+		const client = new FakeClient([
+			{ kind: "thread", threadId: "thr_worker_parent" },
+			{
+				kind: "requires_action",
+				runId: "run_parent",
+				calls: [
+					{
+						id: "call_agent",
+						name: "Agent",
+						input: { prompt: "nested implement", subagent_type: "worker" },
+					},
+				],
+			},
+			{ kind: "thread", threadId: "thr_worker_child" },
+			{ kind: "assistant_delta", text: "nested report" },
+			{ kind: "completed" },
+		]);
+		const tools = createDefaultTools({ client, config });
+		const agent = tools.find((t): t is AgentTool => t.name === "Agent");
+
+		if (!agent) throw new Error("expected Agent tool");
+		await agent.execute({ prompt: "implement" }, context());
+
+		expect(client.messageRequests).toHaveLength(2);
+		for (const request of client.messageRequests) {
+			expect(request.llm_provider).toBe("moonshot");
+			expect(request.model_name).toBe("kimi-k3");
+		}
+	});
+
 	it("does not execute stale hidden worker tool calls", async () => {
 		const config = new Config({
 			env: TEST_BACKBOARD_ENV,
@@ -178,10 +240,10 @@ describe("createDefaultTools", () => {
 
 		expect(client.messageRequests).toHaveLength(2);
 		expect(toolNames(client.messageRequests[0]?.tools ?? [])).not.toContain(
-			"Execute",
+			"execute",
 		);
 		expect(toolNames(client.messageRequests[1]?.tools ?? [])).not.toContain(
-			"Execute",
+			"execute",
 		);
 	});
 

--- a/tests/deadlineHandoff.test.ts
+++ b/tests/deadlineHandoff.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "bun:test";
+import { BackgroundAgentSupervisor } from "../src/core/agent/BackgroundAgentSupervisor.ts";
+import { RunBudget } from "../src/core/agent/RunBudget.ts";
+import { SubAgentRunner } from "../src/core/agent/SubAgentRunner.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { EventBus } from "../src/core/bus/EventBus.ts";
+import { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
+import type {
+	ProviderEvent,
+	SendMessageRequest,
+} from "../src/providers/backboard/types.ts";
+import { TEST_BACKBOARD_ENV, TEST_MODEL } from "./helpers/agent.ts";
+import { TestTool } from "./helpers.ts";
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+function definition(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+	return {
+		name: "slowpoke",
+		description: "d",
+		mode: "worker",
+		systemPrompt: "p",
+		source: "project",
+		...overrides,
+	};
+}
+
+/** Streams a partial answer, keeps working past the budget, then finishes. */
+class SlowClient extends BackboardClient {
+	requests: SendMessageRequest[] = [];
+	finished = false;
+
+	constructor(private readonly workMs: number) {
+		super(TEST_BACKBOARD_ENV);
+	}
+
+	override async *runMessage(
+		req: SendMessageRequest,
+		options: { signal?: AbortSignal } = {},
+	): AsyncIterable<ProviderEvent> {
+		this.requests.push(req);
+		yield { kind: "thread", threadId: "thr" };
+		// The post-timeout summary turn answers at once; only the first request
+		// represents the long-running task.
+		if (this.requests.length > 1) {
+			yield { kind: "assistant_delta", text: "partial progress" };
+			yield { kind: "completed" };
+			return;
+		}
+		const step = 5;
+		for (let waited = 0; waited < this.workMs; waited += step) {
+			await sleep(step);
+			if (options.signal?.aborted) throw new Error("aborted");
+		}
+		this.finished = true;
+		yield { kind: "assistant_delta", text: "finished the long task" };
+		yield { kind: "completed" };
+	}
+
+	override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+		yield { kind: "completed" };
+	}
+	override async listAssistants() {
+		return [];
+	}
+	override async createAssistant() {
+		return { assistant_id: "a", name: "t" };
+	}
+}
+
+function runnerWith(client: BackboardClient): SubAgentRunner {
+	return new SubAgentRunner({
+		client,
+		getModel: () => TEST_MODEL,
+		memory: "off",
+		memoryProfile: "code",
+		getThinking: async () => undefined,
+		toolFactory: () => [],
+	});
+}
+
+describe("RunBudget expiry modes", () => {
+	it("signals expiry without aborting when abortOnExpiry is false", async () => {
+		const budget = RunBudget.start(new AbortController().signal, 10, {
+			abortOnExpiry: false,
+		});
+		await budget.expiry;
+		expect(budget.timedOut).toBe(true);
+		expect(budget.signal.aborted).toBe(false);
+		budget.dispose();
+	});
+
+	it("stops forwarding parent cancellation once detached", () => {
+		const parent = new AbortController();
+		const budget = RunBudget.start(parent.signal, 10_000, {
+			abortOnExpiry: false,
+		});
+		budget.detachFromParent();
+		parent.abort();
+		expect(budget.signal.aborted).toBe(false);
+		budget.dispose();
+	});
+});
+
+describe("deadline handoff", () => {
+	it("keeps the run alive and returns a handle instead of killing it", async () => {
+		const client = new SlowClient(200);
+		let continuation: Promise<unknown> | undefined;
+
+		const result = await runnerWith(client).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			onDeadline: ({ continuation: pending }) => {
+				continuation = pending;
+				return { runId: "bg_test" };
+			},
+		});
+
+		expect(result.status).toBe("backgrounded");
+		expect(result.runId).toBe("bg_test");
+		expect(client.finished).toBe(false);
+
+		// The work was never interrupted; it finishes on its own afterwards.
+		const settled = (await continuation) as { status: string; report: string };
+		expect(client.finished).toBe(true);
+		expect(settled.status).toBe("completed");
+		expect(settled.report).toBe("finished the long task");
+	});
+
+	it("survives a parent cancel issued after the handoff", async () => {
+		const client = new SlowClient(200);
+		const parent = new AbortController();
+		let continuation: Promise<unknown> | undefined;
+
+		await runnerWith(client).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: parent.signal,
+			onDeadline: ({ continuation: pending }) => {
+				continuation = pending;
+				return { runId: "bg_test" };
+			},
+		});
+
+		parent.abort();
+		const settled = (await continuation) as { status: string };
+		expect(settled.status).toBe("completed");
+		expect(client.finished).toBe(true);
+	});
+
+	it("falls back to stopping and summarizing when the handoff declines", async () => {
+		const client = new SlowClient(200);
+		const result = await runnerWith(client).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			onDeadline: () => undefined,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(client.finished).toBe(false);
+	});
+
+	it("still stops and summarizes when no handoff is offered at all", async () => {
+		const client = new SlowClient(200);
+		const result = await runnerWith(client).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(client.finished).toBe(false);
+	});
+});
+
+describe("budgets inside a backgrounded chain", () => {
+	it("lets a nested run finish instead of killing it when nobody waits", async () => {
+		const client = new SlowClient(200);
+		const result = await runnerWith(client).run({
+			prompt: "nested work",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 2,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			// Its spawner already moved to the background.
+			parentInBackground: true,
+		});
+
+		// Ran past its budget, finished, and reported to its parent normally.
+		expect(result.status).toBe("completed");
+		expect(result.report).toBe("finished the long task");
+		expect(client.finished).toBe(true);
+		expect(client.requests).toHaveLength(1);
+	});
+
+	it("still enforces the budget while a foreground parent waits", async () => {
+		const client = new SlowClient(200);
+		const result = await runnerWith(client).run({
+			prompt: "nested work",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 2,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			parentInBackground: false,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(client.finished).toBe(false);
+	});
+
+	it("marks its own children as being in the background chain", async () => {
+		const probe = new TestTool({ name: "Read", readOnly: true });
+		const run = probe.execute.bind(probe);
+		let seen: boolean | undefined;
+		probe.execute = (input, toolCtx) => {
+			seen = toolCtx.inBackgroundChain;
+			return run(input, toolCtx);
+		};
+
+		class OneRoundClient extends SlowClient {
+			constructor() {
+				super(1);
+			}
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "t" };
+				yield {
+					kind: "requires_action",
+					runId: "r",
+					calls: [{ id: "c1", name: "Read", input: {} }],
+				};
+			}
+			override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+				yield { kind: "assistant_delta", text: "done" };
+				yield { kind: "completed" };
+			}
+		}
+
+		const runner = new SubAgentRunner({
+			client: new OneRoundClient(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [probe],
+		});
+		await runner.run({
+			prompt: "x",
+			definition: definition(),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			chainInBackground: true,
+		});
+
+		expect(seen).toBe(true);
+	});
+});
+
+describe("stopping a handed-off run", () => {
+	it("cancelAll reaches a run adopted after its budget expired", async () => {
+		const client = new SlowClient(2_000);
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		const result = await runnerWith(client).run({
+			prompt: "very long task",
+			definition: definition({ timeoutMs: 30 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			onDeadline: ({ continuation, cancel }) => ({
+				runId: supervisor.adopt({
+					definition: definition(),
+					prompt: "very long task",
+					continuation,
+					cancel,
+				}).id,
+			}),
+		});
+
+		expect(result.status).toBe("backgrounded");
+		expect(supervisor.active).toHaveLength(1);
+
+		// Without a working stop handle this run would outlive the session.
+		supervisor.cancelAll();
+		await sleep(120);
+
+		expect(supervisor.active).toHaveLength(0);
+		expect(client.finished).toBe(false);
+		// A deliberate cancel is silent; it must not announce itself.
+		expect(reports).toEqual([]);
+	});
+});
+
+describe("supervisor adoption", () => {
+	it("reports an adopted run when it eventually finishes", async () => {
+		const supervisor = new BackgroundAgentSupervisor(new EventBus());
+		const reports: string[] = [];
+		supervisor.setNotifier((report) => reports.push(report));
+
+		let resolve!: (value: {
+			report: string;
+			status: "completed";
+			usage: Record<string, never>;
+			toolRounds: number;
+		}) => void;
+		const continuation = new Promise<{
+			report: string;
+			status: "completed";
+			usage: Record<string, never>;
+			toolRounds: number;
+		}>((r) => {
+			resolve = r;
+		});
+
+		const snapshot = supervisor.adopt({
+			definition: definition(),
+			prompt: "long task",
+			continuation,
+			cancel: () => {},
+		});
+
+		expect(snapshot.status).toBe("running");
+		expect(snapshot.adopted).toBe(true);
+		expect(supervisor.active).toHaveLength(1);
+		expect(reports).toEqual([]);
+
+		resolve({
+			report: "done at last",
+			status: "completed",
+			usage: {},
+			toolRounds: 9,
+		});
+		await sleep(40);
+
+		expect(supervisor.active).toHaveLength(0);
+		expect(reports).toHaveLength(1);
+		expect(reports[0]).toContain("done at last");
+		expect(reports[0]).toContain('rounds="9"');
+	});
+});

--- a/tests/deadlineHandoff.test.ts
+++ b/tests/deadlineHandoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { RuntimeThinkingResolver } from "../src/config/thinkingRuntime.ts";
 import { BackgroundAgentSupervisor } from "../src/core/agent/BackgroundAgentSupervisor.ts";
 import { RunBudget } from "../src/core/agent/RunBudget.ts";
 import { SubAgentRunner } from "../src/core/agent/SubAgentRunner.ts";
@@ -195,7 +196,7 @@ describe("budgets inside a backgrounded chain", () => {
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
 			// Its spawner already moved to the background.
-			parentInBackground: true,
+			parentChain: { inBackground: true },
 		});
 
 		// Ran past its budget, finished, and reported to its parent normally.
@@ -213,7 +214,7 @@ describe("budgets inside a backgrounded chain", () => {
 			depth: 2,
 			parentCwd: process.cwd(),
 			parentSignal: new AbortController().signal,
-			parentInBackground: false,
+			parentChain: { inBackground: false },
 		});
 
 		expect(result.status).toBe("timed_out");
@@ -241,7 +242,7 @@ describe("budgets inside a backgrounded chain", () => {
 		const run = probe.execute.bind(probe);
 		let seen: boolean | undefined;
 		probe.execute = (input, toolCtx) => {
-			seen = toolCtx.inBackgroundChain;
+			seen = toolCtx.backgroundChain?.inBackground;
 			return run(input, toolCtx);
 		};
 
@@ -281,6 +282,206 @@ describe("budgets inside a backgrounded chain", () => {
 		});
 
 		expect(seen).toBe(true);
+	});
+});
+
+describe("handoff moves the live run into the background chain", () => {
+	it("passes the new value to tools that run after adoption", async () => {
+		const probe = new TestTool({ name: "Read", readOnly: true });
+		const run = probe.execute.bind(probe);
+		const seen: boolean[] = [];
+		probe.execute = (input, toolCtx) => {
+			seen.push(toolCtx.backgroundChain?.inBackground === true);
+			return run(input, toolCtx);
+		};
+
+		/** One tool round before the budget expires, one after the handoff. */
+		class ToolAcrossDeadline extends SlowClient {
+			private round = 0;
+			constructor() {
+				super(1);
+			}
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "t" };
+				yield {
+					kind: "requires_action",
+					runId: "r",
+					calls: [{ id: "c1", name: "Read", input: {} }],
+				};
+			}
+			override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+				this.round++;
+				if (this.round === 1) {
+					await sleep(120);
+					yield {
+						kind: "requires_action",
+						runId: "r",
+						calls: [{ id: "c2", name: "Read", input: {} }],
+					};
+					return;
+				}
+				yield { kind: "assistant_delta", text: "done" };
+				yield { kind: "completed" };
+			}
+		}
+
+		const runner = new SubAgentRunner({
+			client: new ToolAcrossDeadline(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [probe],
+		});
+
+		let continuation: Promise<unknown> | undefined;
+		const result = await runner.run({
+			prompt: "x",
+			definition: definition({ timeoutMs: 40 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			onDeadline: ({ continuation: pending }) => {
+				continuation = pending;
+				return { runId: "bg_test" };
+			},
+		});
+		expect(result.status).toBe("backgrounded");
+		await continuation;
+
+		// Budgets stop being enforced below a run moved to the background, so
+		// the tool call after adoption must observe that.
+		expect(seen).toEqual([false, true]);
+	});
+});
+
+describe("a handoff reaches runs below it through the parent chain", () => {
+	it("flips a child's chain state when its parent is handed off", () => {
+		// Stand-in for a parent run's live state object.
+		const parent = { inBackground: false };
+		let seen: boolean | undefined;
+		const probe = new TestTool({ name: "Read", readOnly: true });
+		const run = probe.execute.bind(probe);
+		probe.execute = (input, toolCtx) => {
+			seen = toolCtx.backgroundChain?.inBackground;
+			return run(input, toolCtx);
+		};
+
+		class ReadAfterParentHandoff extends SlowClient {
+			constructor() {
+				super(1);
+			}
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "t" };
+				// The parent is backgrounded while this child is mid-turn.
+				parent.inBackground = true;
+				yield {
+					kind: "requires_action",
+					runId: "r",
+					calls: [{ id: "c1", name: "Read", input: {} }],
+				};
+			}
+			override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+				yield { kind: "assistant_delta", text: "done" };
+				yield { kind: "completed" };
+			}
+		}
+
+		const runner = new SubAgentRunner({
+			client: new ReadAfterParentHandoff(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [probe],
+		});
+		return runner
+			.run({
+				prompt: "x",
+				definition: definition(),
+				depth: 2,
+				parentCwd: process.cwd(),
+				parentSignal: new AbortController().signal,
+				parentChain: parent,
+			})
+			.then(() => {
+				expect(seen).toBe(true);
+			});
+	});
+});
+
+describe("a parent handoff relaxes a running child's budget", () => {
+	it("lets the child run past its deadline once nobody waits", async () => {
+		const client = new SlowClient(120);
+		const parent = { inBackground: false };
+		// The parent is handed off well before the child's 40ms deadline fires.
+		setTimeout(() => {
+			parent.inBackground = true;
+		}, 10);
+
+		const result = await runnerWith(client).run({
+			prompt: "nested work",
+			definition: definition({ timeoutMs: 40 }),
+			depth: 2,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			parentChain: parent,
+		});
+
+		expect(result.status).toBe("completed");
+		expect(client.finished).toBe(true);
+	});
+});
+
+describe("budget covers the model-metadata preflight", () => {
+	/** Its metadata lookup hangs until cancelled, so only the budget can bound it. */
+	function stalledPreflightRunner(client: BackboardClient): SubAgentRunner {
+		return new SubAgentRunner({
+			client,
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			getThinkingResolver: (_model, signal) =>
+				new Promise<RuntimeThinkingResolver>((resolve) => {
+					signal.addEventListener("abort", () =>
+						resolve({ intent: undefined, resolve: () => undefined }),
+					);
+				}),
+			toolFactory: () => [],
+		});
+	}
+
+	it("hands off a run whose preflight stalls past the deadline", async () => {
+		const started = Date.now();
+		const result = await stalledPreflightRunner(new SlowClient(200)).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 20 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			onDeadline: () => ({ runId: "bg_test" }),
+		});
+
+		expect(result.status).toBe("backgrounded");
+		expect(Date.now() - started).toBeLessThan(1_000);
+	});
+
+	it("times out a foreground run whose preflight stalls without a summary turn", async () => {
+		const client = new SlowClient(200);
+		const started = Date.now();
+		const result = await stalledPreflightRunner(client).run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 20 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(Date.now() - started).toBeLessThan(1_000);
+		// No turn ever ran, so there was nothing for a summary turn to salvage.
+		expect(client.requests).toHaveLength(0);
 	});
 });
 
@@ -329,6 +530,7 @@ describe("handoff detaches from the turn's checkpoint", () => {
 					recordPostImage: async () => {
 						journaled++;
 					},
+					revokeCapture: async () => {},
 					revertToolCall: async () => {},
 					beginShellCapture: async () => {},
 					endShellCapture: async () => {},

--- a/tests/deadlineHandoff.test.ts
+++ b/tests/deadlineHandoff.test.ts
@@ -4,6 +4,7 @@ import { RunBudget } from "../src/core/agent/RunBudget.ts";
 import { SubAgentRunner } from "../src/core/agent/SubAgentRunner.ts";
 import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
 import { EventBus } from "../src/core/bus/EventBus.ts";
+import type { CheckpointRecorder } from "../src/core/checkpoints/CheckpointStore.ts";
 import { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
 import type {
 	ProviderEvent,
@@ -264,6 +265,82 @@ describe("budgets inside a backgrounded chain", () => {
 		});
 
 		expect(seen).toBe(true);
+	});
+});
+
+describe("handoff detaches from the turn's checkpoint", () => {
+	it("stops journaling once the turn that owned it has ended", async () => {
+		const probe = new TestTool({ name: "Read", readOnly: true });
+		const run = probe.execute.bind(probe);
+		let journaled = 0;
+		let captured: { checkpoints?: CheckpointRecorder } | undefined;
+		probe.execute = (input, toolCtx) => {
+			captured = toolCtx;
+			return run(input, toolCtx);
+		};
+
+		class ToolThenStall extends SlowClient {
+			constructor() {
+				super(1);
+			}
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "t" };
+				yield {
+					kind: "requires_action",
+					runId: "r",
+					calls: [{ id: "c1", name: "Read", input: {} }],
+				};
+			}
+			override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+				await sleep(400);
+				yield { kind: "assistant_delta", text: "done" };
+				yield { kind: "completed" };
+			}
+		}
+
+		const runner = new SubAgentRunner({
+			client: new ToolThenStall(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [probe],
+			checkpoints: {
+				scopedToTurn: () => ({
+					recordPreImage: async () => {
+						journaled++;
+					},
+					recordPostImage: async () => {
+						journaled++;
+					},
+					revertToolCall: async () => {},
+					beginShellCapture: async () => {},
+					endShellCapture: async () => {},
+					captureWarning: () => null,
+					scopedToTurn: () => {
+						throw new Error("unused");
+					},
+				}),
+			} as never,
+		});
+
+		const result = await runner.run({
+			prompt: "long task",
+			definition: definition({ timeoutMs: 60 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			parentTurnId: "turn_1",
+			onDeadline: () => ({ runId: "bg_test" }),
+		});
+
+		expect(result.status).toBe("backgrounded");
+		expect(captured?.checkpoints).toBeDefined();
+
+		// After handoff the turn's checkpoint is finalized, so an edit the run
+		// makes from here must not be journaled into it.
+		await captured?.checkpoints?.recordPreImage("/tmp/x", {} as never);
+		expect(journaled).toBe(0);
 	});
 });
 

--- a/tests/deadlineHandoff.test.ts
+++ b/tests/deadlineHandoff.test.ts
@@ -220,6 +220,22 @@ describe("budgets inside a backgrounded chain", () => {
 		expect(client.finished).toBe(false);
 	});
 
+	it("still enforces the budget of the run that started in the background", async () => {
+		const client = new SlowClient(200);
+		const result = await runnerWith(client).run({
+			prompt: "watch the build",
+			definition: definition({ timeoutMs: 30, background: true }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+			chainInBackground: true,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(result.report).toBe("partial progress");
+		expect(client.finished).toBe(false);
+	});
+
 	it("marks its own children as being in the background chain", async () => {
 		const probe = new TestTool({ name: "Read", readOnly: true });
 		const run = probe.execute.bind(probe);

--- a/tests/delegatableTools.test.ts
+++ b/tests/delegatableTools.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import type { Tool } from "../src/core/tools/Tool.ts";
+import { selectDelegatableTools } from "../src/tools/delegatableTools.ts";
+import { TestTool } from "./helpers.ts";
+
+const AGENT_TOOL = new TestTool({ name: "Agent", readOnly: false });
+
+function candidates(): Tool[] {
+	return [
+		new TestTool({ name: "Read", readOnly: true }),
+		new TestTool({ name: "Grep", readOnly: true }),
+		new TestTool({ name: "Write", readOnly: false }),
+		new TestTool({ name: "AskUser", readOnly: true }),
+		new TestTool({ name: "Browser", readOnly: true }),
+		AGENT_TOOL,
+	];
+}
+
+function definition(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+	return {
+		name: "a",
+		description: "d",
+		mode: "worker",
+		systemPrompt: "p",
+		source: "project",
+		...overrides,
+	};
+}
+
+function select(
+	def: AgentDefinition,
+	isToolEnabled: (name: string) => boolean = () => true,
+): string[] {
+	return selectDelegatableTools({
+		definition: def,
+		candidates: candidates(),
+		agentTool: AGENT_TOOL,
+		isToolEnabled,
+	}).map((tool) => tool.agentName);
+}
+
+describe("selectDelegatableTools", () => {
+	it("drops non-delegatable tools and keeps the rest", () => {
+		const names = select(definition());
+		expect(names).not.toContain("ask_user");
+		expect(names).not.toContain("browser");
+		expect(names).toEqual(
+			expect.arrayContaining(["read", "grep", "write", "agent"]),
+		);
+	});
+
+	it("restricts to the definition's tools allowlist", () => {
+		expect(select(definition({ tools: ["read", "grep"] }))).toEqual([
+			"read",
+			"grep",
+		]);
+	});
+
+	it("removes disallowed tools", () => {
+		const names = select(definition({ disallowedTools: ["write"] }));
+		expect(names).toContain("read");
+		expect(names).not.toContain("write");
+	});
+
+	it("omits nested delegation unless the allowlist names the agent tool", () => {
+		expect(select(definition({ tools: ["read"] }))).not.toContain("agent");
+		expect(select(definition({ tools: ["read", "agent"] }))).toContain("agent");
+	});
+
+	it("omits nested delegation when the agent tool is disallowed or disabled", () => {
+		expect(select(definition({ disallowedTools: ["agent"] }))).not.toContain(
+			"agent",
+		);
+		expect(select(definition(), (name) => name !== "agent")).not.toContain(
+			"agent",
+		);
+	});
+
+	it("never lists the agent tool twice", () => {
+		const names = select(definition());
+		expect(names.filter((name) => name === "agent")).toHaveLength(1);
+	});
+});

--- a/tests/semaphore.test.ts
+++ b/tests/semaphore.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { Semaphore } from "../src/utils/semaphore.ts";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+describe("Semaphore", () => {
+	it("rejects non-positive permit counts", () => {
+		expect(() => new Semaphore(0)).toThrow();
+		expect(() => new Semaphore(1.5)).toThrow();
+	});
+
+	it("caps concurrent holders and queues the rest", async () => {
+		const semaphore = new Semaphore(2);
+		const gates = [deferred(), deferred(), deferred()];
+		let active = 0;
+		let peak = 0;
+
+		const runs = gates.map((gate) =>
+			semaphore.run(async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await gate.promise;
+				active--;
+			}),
+		);
+
+		await Promise.resolve();
+		expect(active).toBe(2);
+
+		for (const gate of gates) gate.resolve();
+		await Promise.all(runs);
+		expect(peak).toBe(2);
+	});
+
+	it("releases the permit when the task throws", async () => {
+		const semaphore = new Semaphore(1);
+		await expect(
+			semaphore.run(async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		await expect(semaphore.run(async () => "ok")).resolves.toBe("ok");
+	});
+
+	it("grants queued waiters in FIFO order", async () => {
+		const semaphore = new Semaphore(1);
+		const order: number[] = [];
+		const gate = deferred();
+
+		const first = semaphore.run(async () => {
+			order.push(0);
+			await gate.promise;
+		});
+		const rest = [1, 2, 3].map((n) =>
+			semaphore.run(async () => {
+				order.push(n);
+			}),
+		);
+
+		gate.resolve();
+		await Promise.all([first, ...rest]);
+		expect(order).toEqual([0, 1, 2, 3]);
+	});
+});

--- a/tests/spawnTree.test.ts
+++ b/tests/spawnTree.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { SubAgentRunner } from "../src/core/agent/SubAgentRunner.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import {
+	type AgentToolOutput,
+	formatSpawnTree,
+} from "../src/core/tools/AgentToolOutput.ts";
+import { Tool } from "../src/core/tools/Tool.ts";
+import { ok, type ToolResult } from "../src/core/tools/ToolResult.ts";
+import { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
+import type { ProviderEvent } from "../src/providers/backboard/types.ts";
+import { TEST_BACKBOARD_ENV, TEST_MODEL } from "./helpers/agent.ts";
+
+const DEF: AgentDefinition = {
+	name: "builder",
+	description: "d",
+	mode: "worker",
+	systemPrompt: "p",
+	source: "project",
+};
+
+/** One tool round calling the Agent tool, then a final answer. */
+class SpawningClient extends BackboardClient {
+	constructor() {
+		super(TEST_BACKBOARD_ENV);
+	}
+	override async *runMessage(): AsyncIterable<ProviderEvent> {
+		yield { kind: "thread", threadId: "t" };
+		yield {
+			kind: "requires_action",
+			runId: "r",
+			calls: [{ id: "c1", name: "agent", input: { prompt: "dig" } }],
+		};
+	}
+	override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+		yield { kind: "assistant_delta", text: "built it" };
+		yield { kind: "completed" };
+	}
+	override async listAssistants() {
+		return [];
+	}
+	override async createAssistant() {
+		return { assistant_id: "a", name: "t" };
+	}
+}
+
+/** Stands in for a nested Agent tool, reporting its own spawn tree. */
+class FakeAgentTool extends Tool<{ prompt?: string }, AgentToolOutput> {
+	readonly name = "Agent";
+	readonly inputSchema = z.object({ prompt: z.string().optional() });
+
+	override isReadOnly(): boolean {
+		return false;
+	}
+
+	// The real Agent tool auto-allows; its children are gated individually.
+	override checkPermissions() {
+		return { behavior: "allow" as const, reason: "test" };
+	}
+
+	override async execute(): Promise<ToolResult<AgentToolOutput>> {
+		return ok(
+			{
+				mode: "worker",
+				agent: "researcher",
+				report: "found it",
+				status: "completed",
+				rounds: 4,
+				children: [{ agent: "scribe", status: "completed", rounds: 2 }],
+			},
+			"found it",
+			"Completed in 4 rounds",
+		);
+	}
+}
+
+describe("spawn tree", () => {
+	it("reports the sub-agents a sub-agent created, and theirs", async () => {
+		const runner = new SubAgentRunner({
+			client: new SpawningClient(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [new FakeAgentTool()],
+		});
+
+		const result = await runner.run({
+			prompt: "build it",
+			definition: DEF,
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(result.report).toBe("built it");
+		expect(result.children).toEqual([
+			{
+				agent: "researcher",
+				status: "completed",
+				rounds: 4,
+				children: [{ agent: "scribe", status: "completed", rounds: 2 }],
+			},
+		]);
+	});
+
+	it("omits the field when a sub-agent spawned nothing", async () => {
+		class Plain extends SpawningClient {
+			override async *runMessage(): AsyncIterable<ProviderEvent> {
+				yield { kind: "thread", threadId: "t" };
+				yield { kind: "assistant_delta", text: "done alone" };
+				yield { kind: "completed" };
+			}
+		}
+		const runner = new SubAgentRunner({
+			client: new Plain(),
+			getModel: () => TEST_MODEL,
+			memory: "off",
+			memoryProfile: "code",
+			getThinking: async () => undefined,
+			toolFactory: () => [],
+		});
+		const result = await runner.run({
+			prompt: "x",
+			definition: DEF,
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+		expect(result.children).toBeUndefined();
+	});
+});
+
+describe("formatSpawnTree", () => {
+	it("nests descendants and flags work still running", () => {
+		expect(
+			formatSpawnTree([
+				{ agent: "researcher", status: "completed", rounds: 4 },
+				{
+					agent: "watcher",
+					status: "backgrounded",
+					rounds: 3,
+					runId: "bg_9a12",
+					children: [{ agent: "scribe", status: "completed", rounds: 1 }],
+				},
+			]),
+		).toBe(
+			[
+				"  - researcher — completed, 4 rounds",
+				"  - watcher — still running in background (bg_9a12)",
+				"    - scribe — completed, 1 round",
+			].join("\n"),
+		);
+	});
+});

--- a/tests/startNewSession.test.ts
+++ b/tests/startNewSession.test.ts
@@ -7,6 +7,7 @@ describe("startNewSession", () => {
 
 		await expect(
 			startNewSession({
+				detach: () => {},
 				activate: async () => {
 					throw new Error("session init failed");
 				},
@@ -17,5 +18,19 @@ describe("startNewSession", () => {
 		).rejects.toThrow("session init failed");
 
 		expect(reset).toBe(false);
+	});
+
+	it("detaches the outgoing session before activation rotates storage", async () => {
+		const order: string[] = [];
+
+		await startNewSession({
+			detach: () => order.push("detach"),
+			activate: async () => {
+				order.push("activate");
+			},
+			resetThread: () => order.push("resetThread"),
+		});
+
+		expect(order).toEqual(["detach", "activate", "resetThread"]);
 	});
 });

--- a/tests/startNewSession.test.ts
+++ b/tests/startNewSession.test.ts
@@ -7,7 +7,7 @@ describe("startNewSession", () => {
 
 		await expect(
 			startNewSession({
-				detach: () => {},
+				detach: async () => {},
 				activate: async () => {
 					throw new Error("session init failed");
 				},
@@ -24,7 +24,9 @@ describe("startNewSession", () => {
 		const order: string[] = [];
 
 		await startNewSession({
-			detach: () => order.push("detach"),
+			detach: async () => {
+				order.push("detach");
+			},
 			activate: async () => {
 				order.push("activate");
 			},

--- a/tests/subAgentTimeout.test.ts
+++ b/tests/subAgentTimeout.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "bun:test";
+import { RunBudget, RunTimeoutError } from "../src/core/agent/RunBudget.ts";
+import { SubAgentRunner } from "../src/core/agent/SubAgentRunner.ts";
+import type { AgentDefinition } from "../src/core/agents/AgentDefinition.ts";
+import { BackboardClient } from "../src/providers/backboard/BackboardClient.ts";
+import type {
+	ProviderEvent,
+	SendMessageRequest,
+} from "../src/providers/backboard/types.ts";
+import { TEST_BACKBOARD_ENV, TEST_MODEL } from "./helpers/agent.ts";
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+function definition(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+	return {
+		name: "slowpoke",
+		description: "d",
+		mode: "worker",
+		systemPrompt: "you are a sub-agent",
+		source: "project",
+		...overrides,
+	};
+}
+
+/**
+ * Streams a partial answer, then stalls past the budget. The follow-up
+ * (summary) request answers immediately.
+ */
+class StallingClient extends BackboardClient {
+	requests: SendMessageRequest[] = [];
+
+	constructor(private readonly stallMs: number) {
+		super(TEST_BACKBOARD_ENV);
+	}
+
+	override async *runMessage(
+		req: SendMessageRequest,
+		options: { signal?: AbortSignal } = {},
+	): AsyncIterable<ProviderEvent> {
+		this.requests.push(req);
+		yield { kind: "thread", threadId: "thr_sub" };
+
+		if (this.requests.length > 1) {
+			yield {
+				kind: "assistant_delta",
+				text: "partial findings, then time ran out",
+			};
+			yield { kind: "completed" };
+			return;
+		}
+
+		yield { kind: "assistant_delta", text: "started investigating" };
+		await sleep(this.stallMs);
+		if (options.signal?.aborted) throw new Error("aborted");
+		yield { kind: "completed" };
+	}
+
+	override async *runToolOutputs(): AsyncIterable<ProviderEvent> {
+		yield { kind: "completed" };
+	}
+}
+
+function runnerWith(client: BackboardClient): SubAgentRunner {
+	return new SubAgentRunner({
+		client,
+		getModel: () => TEST_MODEL,
+		memory: "off",
+		memoryProfile: "code",
+		getThinking: async () => undefined,
+		toolFactory: () => [],
+	});
+}
+
+describe("RunBudget", () => {
+	it("expires on its own deadline and reports timedOut", async () => {
+		const budget = RunBudget.start(new AbortController().signal, 10);
+		await sleep(30);
+		expect(budget.timedOut).toBe(true);
+		expect(budget.signal.aborted).toBe(true);
+		expect(() => budget.throwIfExpired()).toThrow(RunTimeoutError);
+		budget.dispose();
+	});
+
+	it("does not report timedOut when the parent cancels", () => {
+		const controller = new AbortController();
+		const budget = RunBudget.start(controller.signal, 10_000);
+		controller.abort();
+		expect(budget.signal.aborted).toBe(true);
+		expect(budget.timedOut).toBe(false);
+		budget.dispose();
+	});
+
+	it("treats an already-aborted parent as an immediate abort, not a timeout", () => {
+		const controller = new AbortController();
+		controller.abort();
+		const budget = RunBudget.start(controller.signal, 10_000);
+		expect(budget.signal.aborted).toBe(true);
+		expect(budget.timedOut).toBe(false);
+		budget.dispose();
+	});
+
+	it("counts down remainingMs and leaves it unset without a budget", () => {
+		const unbounded = RunBudget.start(new AbortController().signal);
+		expect(unbounded.remainingMs).toBeUndefined();
+		unbounded.dispose();
+
+		const bounded = RunBudget.start(new AbortController().signal, 5_000);
+		const remaining = bounded.remainingMs ?? 0;
+		expect(remaining).toBeGreaterThan(0);
+		expect(remaining).toBeLessThanOrEqual(5_000);
+		bounded.dispose();
+	});
+});
+
+describe("SubAgentRunner timeouts", () => {
+	it("summarizes partial progress instead of discarding a timed-out run", async () => {
+		const client = new StallingClient(500);
+		const result = await runnerWith(client).run({
+			prompt: "investigate",
+			definition: definition({ timeoutMs: 40 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(result.status).toBe("timed_out");
+		expect(result.report).toBe("partial findings, then time ran out");
+		// Two requests: the timed-out run, then the bounded summary turn.
+		expect(client.requests).toHaveLength(2);
+		expect(client.requests[1]?.content).toContain("time budget expired");
+		expect(client.requests[1]?.tools ?? []).toEqual([]);
+	});
+
+	it("reports cancelled, not timed_out, when the parent aborts", async () => {
+		const client = new StallingClient(500);
+		const controller = new AbortController();
+		const run = runnerWith(client).run({
+			prompt: "investigate",
+			definition: definition({ timeoutMs: 10_000 }),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: controller.signal,
+		});
+		await sleep(30);
+		controller.abort();
+
+		const result = await run;
+		expect(result.status).toBe("cancelled");
+		// No summary turn: the user asked for it to stop.
+		expect(client.requests).toHaveLength(1);
+	});
+
+	it("runs without a deadline when the definition sets no timeout", async () => {
+		const client = new StallingClient(1);
+		const result = await runnerWith(client).run({
+			prompt: "investigate",
+			definition: definition(),
+			depth: 1,
+			parentCwd: process.cwd(),
+			parentSignal: new AbortController().signal,
+		});
+
+		expect(result.status).toBe("completed");
+		expect(client.requests).toHaveLength(1);
+	});
+});

--- a/tests/submitPriority.test.ts
+++ b/tests/submitPriority.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type QueuedSubmit,
+	SUBMIT_PRIORITY_ORDER,
+	type SubmitPriority,
+} from "../src/core/agent/AgentControllerTypes.ts";
+
+/**
+ * Mirrors AgentController.takeNextSubmit. The controller needs a live client to
+ * drain for real, so the selection rule is exercised directly — it is the part
+ * that decides whether background reports can starve the user.
+ */
+function takeNext(queue: QueuedSubmit[]): QueuedSubmit | undefined {
+	let bestIndex = -1;
+	let bestRank = Number.POSITIVE_INFINITY;
+	for (const [index, queued] of queue.entries()) {
+		const rank = SUBMIT_PRIORITY_ORDER[queued.priority];
+		if (rank < bestRank) {
+			bestIndex = index;
+			bestRank = rank;
+		}
+	}
+	if (bestIndex === -1) return undefined;
+	return queue.splice(bestIndex, 1)[0];
+}
+
+function queued(text: string, priority: SubmitPriority): QueuedSubmit {
+	return {
+		text,
+		priority,
+		emitUserMessage: false,
+		resolve: () => {},
+		reject: () => {},
+	};
+}
+
+function drain(queue: QueuedSubmit[]): string[] {
+	const order: string[] = [];
+	let next = takeNext(queue);
+	while (next) {
+		order.push(next.text);
+		next = takeNext(queue);
+	}
+	return order;
+}
+
+describe("submit priority", () => {
+	it("orders now before next before later", () => {
+		const queue = [
+			queued("report", "later"),
+			queued("user", "next"),
+			queued("steer", "now"),
+		];
+		expect(drain(queue)).toEqual(["steer", "user", "report"]);
+	});
+
+	it("keeps FIFO within a tier", () => {
+		const queue = [
+			queued("first", "next"),
+			queued("second", "next"),
+			queued("third", "next"),
+		];
+		expect(drain(queue)).toEqual(["first", "second", "third"]);
+	});
+
+	it("never lets queued reports starve later user input", () => {
+		// Reports land first; the user then types. The user must still go next.
+		const queue = [
+			queued("report-a", "later"),
+			queued("report-b", "later"),
+			queued("user", "next"),
+		];
+		expect(takeNext(queue)?.text).toBe("user");
+	});
+
+	it("lets a steer preempt a queue that already holds a report", () => {
+		const queue = [queued("report", "later"), queued("steer", "now")];
+		expect(takeNext(queue)?.text).toBe("steer");
+	});
+
+	it("returns undefined for an empty queue", () => {
+		expect(takeNext([])).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Sub-agents shared one hardcoded system prompt and inherited the parent's model and tool set wholesale. This makes them definable per project, lets them run past the turn that spawned them, and gives them wall-clock budgets.

## Defining an agent

`.backboard/agents/researcher.md` — frontmatter configures, body becomes the system prompt:

```markdown
---
description: Deep-dives one question, read-only.
tools: [read, grep, glob]
model: anthropic/claude-opus-5
maxRounds: 30
---

You are a read-only research sub-agent. Never modify files.
Report findings as file paths with a one-line summary each.
```

The parent then calls `Agent(subagent_type: "researcher", prompt: "…")`. Identity comes from the file; the task comes from the parent at call time.

## What's in here

**Agent registry** — discovery from `.backboard/agents/*.md` (project) and `~/.backboard/agents` (user), following the existing MCP/hooks config split. Per-agent `tools`, `disallowedTools`, `model`, `maxRounds`, `timeoutMs`, `background`. `subagent_type` becomes a dynamic enum built from the catalog. Invalid files are skipped with a startup warning, never fatal. `worker` and `rlm` remain built-ins, so behaviour is unchanged with no agent files present.

**Background execution** — `background: true` runs an agent past its spawning turn under a supervisor whose cancellation signal is deliberately unlinked from the turn, so cancelling the foreground no longer kills it. Reports arrive through a new `later` tier on the controller's submit queue, selected at drain time so user input can never be starved. Running agents show in the status bar.

**Time budgets** — `RLMBudget` extracted into a shared `RunBudget` and applied to worker agents. On expiry the agent gets one tool-less turn to report what it established rather than having its work discarded, returning `status: timed_out`.

## Fixes found along the way

- **Concurrent spawns were unbounded** — 20 `Agent` calls in one message meant 20 live sessions. Now capped, with a separate pool for background runs.
- **Deadlock risk** — a nested chain holds one permit per level, so `maxConcurrent < maxDepth` could deadlock against itself. Rejected at construction; a test exercises the tight boundary where permits exactly equal depth.
- **`AgentCatalog` was last-write-wins** — precedence only worked because discovery de-duplicated first. The catalog now keeps the first definition itself.
- **Agent reports rendered shredded** — a raw 4000-char slice that the transcript then truncated mid-line. Now routed through `buildOutputPreview` like every other tool.
- **Headless mode promised reports it would cancel** — `--print` exits after one prompt, so background spawns there now run inline.
- **New threads leaked stale reports** — an agent spawned for a discarded conversation would report into the fresh one.

## Design decisions worth reviewing

- **Background is top-level only.** A nested background spawn would outlive the sub-agent that owns it, leaving no one to receive its report. Deeper spawns run inline regardless of the flag.
- **Nesting is opt-in.** An agent that pins `tools` must list `agent` explicitly to keep spawning.
- **`/undo` does not cover background agents.** They outlive their turn's checkpoint, so journaling edits there would write into an already-finalized checkpoint. Capture is disabled instead; the README says to prefer read-only tools for them.
- **Agent names are matched exactly, not normalized.** Lowercasing `Researcher.md` would collide with `researcher.md`, so the rule is stated in the validation error instead.

## Testing

`bun run validate` clean — 1458 pass, 3 skip, 0 fail. Eight new test files covering discovery and parsing, tool-allowlist policy, the semaphore, worker and RLM timeouts, submit-queue priority, the background supervisor, and an end-to-end flow that drives a real `AgentController` + supervisor + `AgentTool` and asserts the spawning turn returns while the agent is still running, that a second user turn is not blocked, and that the report arrives as its own turn afterwards.

Not covered by tests: live Ink rendering, and a model choosing a background agent on its own. Both were exercised manually.

## Review note

The three areas interleave within `AgentTool.tsx`, `SubAgentRunner.ts`, `cli.tsx` and `Store.ts`, so splitting them into separate commits would have produced commits that don't compile. Kept as one commit with the areas separated in the message.


## Follow-up review fix

Discovery rejected only the shape of a `model:` value, not its parts, so `model: /`, `model: anthropic/`, and `model: /claude-opus-5` parsed into a `ModelRef` with an empty half. The agent then looked valid at startup and failed at request time with an unusable model reference. A qualified reference now requires both parts, `inherit` still means "use the session model", and each part is trimmed so `anthropic / claude-opus-5` no longer yields a provider with trailing whitespace. Malformed values produce the documented skip warning naming the offending value. Covered by four rejection cases and a trimming case in `tests/agentDiscovery.test.ts`.

## Rebase note

Supersedes #6. `main` was rewritten after this branch was cut, leaving the two with no common history, so GitHub refused to reopen that PR. The eight commits are rebased onto current `main`; the only conflicts were `src/prompts/tools/agent.tsx` (main replaced the static prompt with the context-aware `buildAgentPrompt()` — the `subagent_type` wording for the registry is carried over onto it) and the startup-warning list in `src/entrypoints/cli.tsx`, which now carries both `agentCatalog.warnings` and main's `renderWarnings`. The set of files touched is identical before and after the rebase.
