### PR TITLE
Add session resume support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 /skills-lock.json
 /skills/
 /prompt-dumps/
+*.bun-build

--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ Or point it at a project explicitly:
 backboard --cwd /path/to/your/project
 ```
 
+Resume a saved Backboard or local BYOK session by the ID shown when the CLI
+exits or in `/sessions`:
+
+```sh
+backboard --resume SESSION_ID
+```
+
 Then enter a normal request:
 
 ```text
@@ -259,7 +266,8 @@ Type `/help` inside R-CLI for the authoritative command list.
 | `/model`                    | Choose a model and thinking mode           |
 | `/settings`                 | Adjust session preferences                 |
 | `/keys`                     | Manage direct provider API keys            |
-| `/sessions`                 | Resume a Backboard or local BYOK session   |
+| `/sessions`, `/session`     | Browse Backboard and local BYOK sessions   |
+| `/resume SESSION_ID`        | Resume a session directly by ID            |
 | `/context`                  | Inspect context-window usage               |
 | `/compress`                 | Compress the current conversation          |
 | `/undo`, `/redo`, `/rewind` | Restore checkpointed file changes          |

--- a/src/config/CliUserError.ts
+++ b/src/config/CliUserError.ts
@@ -1,0 +1,10 @@
+export class CliUserError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CliUserError";
+	}
+}
+
+export function cliUserErrorMessage(error: unknown): string | null {
+	return error instanceof CliUserError ? error.message : null;
+}

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -340,6 +340,17 @@ export class Config {
 		return this.auth.providerKeys.length > 0;
 	}
 
+	hasProviderKeyFor(provider: string): boolean {
+		return this.auth.providerKeys.some((entry) => entry.provider === provider);
+	}
+
+	get hasBackendForCurrentModel(): boolean {
+		return (
+			this.hasBackboardAuth ||
+			this.hasProviderKeyFor(this.currentModel.provider)
+		);
+	}
+
 	/**
 	 * Re-reads credentials after `/login`, `/logout`, or a `/keys` change so the
 	 * running session picks them up without a restart.

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -44,6 +44,12 @@ export interface ConfigOptions {
 	env?: BackboardEnv;
 	argv?: string[];
 	homeDir?: string;
+	/**
+	 * A validated local resume may bootstrap without credentials so the user
+	 * can reopen it and add/re-enable its provider key via /keys.
+	 */
+	resumeModel?: ModelRef;
+	allowUnauthenticatedResume?: boolean;
 }
 
 /** Placeholder env used when the run authenticates with provider keys only. */
@@ -92,7 +98,10 @@ export class Config {
 		if (options.env) {
 			// An injected env is an explicit Backboard credential (tests, evals).
 			this.auth = { ...this.auth, backboard: options.env };
-		} else if (!hasAnyCredentials(this.auth)) {
+		} else if (
+			!hasAnyCredentials(this.auth) &&
+			!options.allowUnauthenticatedResume
+		) {
 			throw new Error(NO_CREDENTIALS_MESSAGE);
 		}
 		this.env = this.auth.backboard ?? anonymousEnv();
@@ -120,7 +129,10 @@ export class Config {
 				: null;
 		this.currentModel = this.flags.model
 			? parseModel(this.flags.model)
-			: (persistedConfig.model ?? keyOnlyDefault ?? this.profile.model);
+			: (options.resumeModel ??
+				persistedConfig.model ??
+				keyOnlyDefault ??
+				this.profile.model);
 		this.currentModelProfile = resolveModelProfile(this.currentModel);
 		this.currentFormat = this.flags.format
 			? parseOutputFormat(this.flags.format)

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -12,6 +12,7 @@ export interface CliFlags {
 	finalVerification?: boolean;
 	lsp?: boolean;
 	fresh?: boolean;
+	resume?: string;
 	login: boolean;
 	logout: boolean;
 	help: boolean;
@@ -127,6 +128,9 @@ export function parseFlags(argv: string[]): CliFlags {
 					value === undefined ? true : parseBooleanFlag(value, "fresh");
 				break;
 			}
+			case "resume":
+				flags.resume = readValue() ?? "";
+				break;
 			case "no-fresh":
 				flags.fresh = false;
 				break;

--- a/src/config/resumeCommand.ts
+++ b/src/config/resumeCommand.ts
@@ -1,0 +1,52 @@
+import { quotePowerShellString } from "../utils/shell.ts";
+import { APP_COMMAND_NAME } from "./branding.ts";
+
+const SAFE_POSIX_ARG = /^[A-Za-z0-9_./:@%+=,-]+$/;
+
+export function buildResumeCommand(
+	argv: readonly string[],
+	sessionId: string,
+	options: {
+		platform?: NodeJS.Platform;
+	},
+): string {
+	const args = withoutResumeFlag(argv);
+	args.push("--resume", sessionId);
+	return [APP_COMMAND_NAME, ...args]
+		.map((arg) => quoteShellArg(arg, options.platform))
+		.join(" ");
+}
+
+export function withoutResumeFlag(argv: readonly string[]): string[] {
+	return withoutFlags(argv, new Set(["resume"]));
+}
+
+function withoutFlags(
+	argv: readonly string[],
+	names: ReadonlySet<string>,
+): string[] {
+	const result: string[] = [];
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		const separatedName = arg?.startsWith("--") ? arg.slice(2) : "";
+		if (names.has(separatedName)) {
+			if (argv[index + 1] && !argv[index + 1]?.startsWith("--")) index += 1;
+			continue;
+		}
+		const inlineName = arg?.match(/^--([^=]+)=/)?.[1];
+		if (inlineName && names.has(inlineName)) continue;
+		if (arg !== undefined) result.push(arg);
+	}
+	return result;
+}
+
+export function quoteShellArg(
+	value: string,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (value.length > 0 && SAFE_POSIX_ARG.test(value)) return value;
+	if (platform === "win32") {
+		return quotePowerShellString(value);
+	}
+	return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}

--- a/src/config/resumePreflight.ts
+++ b/src/config/resumePreflight.ts
@@ -41,3 +41,13 @@ export function isHeadlessInvocation(
 		!io.stdoutIsTTY
 	);
 }
+
+export function canPromptForPermissions(
+	flags: Pick<CliFlags, "print">,
+	format: OutputFormat,
+	io: { stdinIsTTY: boolean } = {
+		stdinIsTTY: Boolean(process.stdin.isTTY),
+	},
+): boolean {
+	return flags.print === undefined && format !== "json" && io.stdinIsTTY;
+}

--- a/src/config/resumePreflight.ts
+++ b/src/config/resumePreflight.ts
@@ -1,0 +1,43 @@
+import { isByokThreadId, isSessionId } from "../utils/id.ts";
+import { CliUserError } from "./CliUserError.ts";
+import type { OutputFormat } from "./defaults.ts";
+import type { CliFlags } from "./flags.ts";
+
+export function parseRequestedResume(value: string): string;
+export function parseRequestedResume(value: undefined): undefined;
+export function parseRequestedResume(
+	value: string | undefined,
+): string | undefined;
+export function parseRequestedResume(
+	value: string | undefined,
+): string | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!normalized) throw new CliUserError("--resume requires a session ID.");
+	if (
+		/^(?:byok|sess)_/i.test(normalized) &&
+		!isByokThreadId(normalized) &&
+		!isSessionId(normalized)
+	) {
+		throw new CliUserError(
+			"Local session IDs must use lowercase sess_ or byok_ followed by 8 hexadecimal characters.",
+		);
+	}
+	return normalized;
+}
+
+export function isHeadlessInvocation(
+	flags: Pick<CliFlags, "print">,
+	format: OutputFormat,
+	io: { stdinIsTTY: boolean; stdoutIsTTY: boolean } = {
+		stdinIsTTY: Boolean(process.stdin.isTTY),
+		stdoutIsTTY: Boolean(process.stdout.isTTY),
+	},
+): boolean {
+	return (
+		flags.print !== undefined ||
+		format === "json" ||
+		!io.stdinIsTTY ||
+		!io.stdoutIsTTY
+	);
+}

--- a/src/core/agent/ProviderStreamConsumer.ts
+++ b/src/core/agent/ProviderStreamConsumer.ts
@@ -90,7 +90,13 @@ export class ProviderStreamConsumer {
 		for await (const event of stream) {
 			switch (event.kind) {
 				case "thread":
-					this.session.threadId = event.threadId;
+					if (this.session.threadId !== event.threadId) {
+						this.session.threadId = event.threadId;
+						this.bus.emit({
+							type: "session:thread",
+							threadId: event.threadId,
+						});
+					}
 					break;
 				case "assistant_delta":
 					if (event.text) assistant.appendDelta(event.text);
@@ -164,15 +170,16 @@ function isRetryableProviderStreamFailure(error: unknown): boolean {
 
 async function waitForRetry(ms: number, signal: AbortSignal): Promise<void> {
 	if (ms <= 0) return;
+	if (signal.aborted) throw new AbortError();
 	await new Promise<void>((resolve, reject) => {
-		const timeout = setTimeout(resolve, ms);
-		signal.addEventListener(
-			"abort",
-			() => {
-				clearTimeout(timeout);
-				reject(new AbortError());
-			},
-			{ once: true },
-		);
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(new AbortError());
+		};
+		const timeout = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal.addEventListener("abort", onAbort, { once: true });
 	});
 }

--- a/src/core/bus/events.ts
+++ b/src/core/bus/events.ts
@@ -92,6 +92,7 @@ export interface AskUserResponse {
  */
 export type AgentEvent =
 	| { type: "session:created"; sessionId: string; threadId: string | null }
+	| { type: "session:thread"; threadId: string }
 	| { type: "user:message"; text: string }
 	| { type: "turn:start"; turnId: string }
 	| { type: "assistant:delta"; turnId: string; messageId: string; text: string }

--- a/src/core/keys/ProviderKeyStore.ts
+++ b/src/core/keys/ProviderKeyStore.ts
@@ -1,11 +1,10 @@
-import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { BACKBOARD_CONFIG_DIR_NAME } from "../../config/paths.ts";
 import { acquireFileLease } from "../../utils/FileLease.ts";
-import { renameOverPreservingDestination } from "../../utils/fs.ts";
+import { writePrivateFileAtomic } from "../../utils/fs.ts";
 import type { JsonValue } from "../../utils/JsonTypes.ts";
 import {
 	decryptSecret,
@@ -187,24 +186,14 @@ async function saveProviderKeys(
 
 	await mkdir(dir, { recursive: true, mode: 0o700 });
 	await chmod(dir, 0o700).catch(() => undefined);
-	const temporary = `${file}.tmp-${process.pid}-${Date.now()}-${randomUUID()}`;
-	try {
-		await writeFile(
-			temporary,
-			`${JSON.stringify(
-				{ version: CURRENT_VERSION, salt: activeSalt, keys: encrypted },
-				null,
-				2,
-			)}\n`,
-			{ mode: 0o600 },
-		);
-		await chmod(temporary, 0o600).catch(() => undefined);
-		await renameOverPreservingDestination(temporary, file);
-		await chmod(file, 0o600).catch(() => undefined);
-	} catch (error) {
-		await rm(temporary, { force: true }).catch(() => undefined);
-		throw error;
-	}
+	await writePrivateFileAtomic(
+		file,
+		`${JSON.stringify(
+			{ version: CURRENT_VERSION, salt: activeSalt, keys: encrypted },
+			null,
+			2,
+		)}\n`,
+	);
 
 	return file;
 }

--- a/src/core/platform/WindowsPlatform.ts
+++ b/src/core/platform/WindowsPlatform.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { quotePowerShellString } from "../../utils/shell.ts";
 import { BasePlatform } from "./BasePlatform.ts";
 import { pngSize, resizeWithCandidates } from "./png.ts";
 import { run, runWithOutput } from "./process.ts";
@@ -22,7 +23,7 @@ export class WindowsPlatform extends BasePlatform {
 			"$bmp=New-Object System.Drawing.Bitmap $b.Width,$b.Height;",
 			"$g=[System.Drawing.Graphics]::FromImage($bmp);",
 			"$g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size);",
-			`$bmp.Save(${powershellString(path)},[System.Drawing.Imaging.ImageFormat]::Png);`,
+			`$bmp.Save(${quotePowerShellString(path)},[System.Drawing.Imaging.ImageFormat]::Png);`,
 			"$g.Dispose();$bmp.Dispose();",
 		].join("");
 		await run("powershell.exe", ["-NoProfile", "-Command", script], signal);
@@ -65,7 +66,7 @@ export class WindowsPlatform extends BasePlatform {
 					[
 						"-NoProfile",
 						"-Command",
-						`Start-Process ${powershellString(action.appName)}`,
+						`Start-Process ${quotePowerShellString(action.appName)}`,
 					],
 					signal,
 				);
@@ -98,13 +99,13 @@ export class WindowsPlatform extends BasePlatform {
 		return resizeWithCandidates(input, async (width, out) => {
 			const script = [
 				"Add-Type -AssemblyName System.Drawing;",
-				`$src=[System.Drawing.Image]::FromFile(${powershellString(input.path)});`,
+				`$src=[System.Drawing.Image]::FromFile(${quotePowerShellString(input.path)});`,
 				`$w=${width};`,
 				"$h=[int]($src.Height*($w/$src.Width));",
 				"$bmp=New-Object System.Drawing.Bitmap $w,$h;",
 				"$g=[System.Drawing.Graphics]::FromImage($bmp);",
 				"$g.DrawImage($src,0,0,$w,$h);",
-				`$bmp.Save(${powershellString(out)},[System.Drawing.Imaging.ImageFormat]::Png);`,
+				`$bmp.Save(${quotePowerShellString(out)},[System.Drawing.Imaging.ImageFormat]::Png);`,
 				"$g.Dispose();$bmp.Dispose();$src.Dispose();",
 			].join("");
 			await run(
@@ -114,10 +115,6 @@ export class WindowsPlatform extends BasePlatform {
 			);
 		});
 	}
-}
-
-function powershellString(value: string): string {
-	return `'${value.replaceAll("'", "''")}'`;
 }
 
 const WINDOWS_ACCESSIBILITY_SCRIPT = [

--- a/src/core/session/ClientEventLog.ts
+++ b/src/core/session/ClientEventLog.ts
@@ -26,9 +26,13 @@ export class ClientEventLog {
 
 	constructor(
 		private sessionId: string,
-		filePath: string,
+		private filePath: string,
 	) {
 		this.writer = new JsonlWriter(filePath);
+	}
+
+	async initialize(): Promise<void> {
+		this.sequence = await nextJsonlSequence(this.filePath);
 	}
 
 	async activate(sessionId: string, filePath: string): Promise<void> {
@@ -42,6 +46,7 @@ export class ClientEventLog {
 			const sequence = await nextJsonlSequence(filePath);
 			await this.writer.flush();
 			this.sessionId = sessionId;
+			this.filePath = filePath;
 			this.sequence = sequence;
 			this.writer = new JsonlWriter(filePath);
 			this.pendingDuringActivation = null;

--- a/src/core/session/ResumeBootstrap.ts
+++ b/src/core/session/ResumeBootstrap.ts
@@ -24,38 +24,35 @@ export async function resolveLocalResumeBootstrap(
 	const normalized = id?.trim();
 	if (!normalized || !isLocalResumeId(normalized)) return null;
 	const conversationStore = new ByokConversationStore(cwd);
-	const likelySessionId = isSessionId(normalized) ? normalized : sessionIdHint;
+	const likelySessionId = isSessionId(normalized)
+		? normalized
+		: sessionIdHint && isSessionId(sessionIdHint)
+			? sessionIdHint
+			: undefined;
 	const directConversation = likelySessionId
 		? await conversationStore.getAtSessionRoot(
 				qSessionDir(cwd, likelySessionId),
 				isByokThreadId(normalized) ? normalized : undefined,
 			)
 		: null;
-	const conversation =
-		directConversation ??
-		(await conversationStore.list()).find(
-			(candidate) =>
-				candidate.threadId === normalized || candidate.sessionId === normalized,
-		);
-	if (conversation) {
+	if (directConversation) return conversationBootstrap(directConversation);
+	if (isSessionId(normalized)) {
+		const meta = await readSessionMeta(cwd, normalized);
+		if (!meta) return null;
 		return {
-			kind: "byok",
-			threadId: conversation.threadId,
-			sessionId: conversation.sessionId,
-			model: {
-				provider: conversation.provider,
-				model: conversation.model,
-			},
+			kind: "session",
+			sessionId: normalized,
+			...(meta.model ? { model: meta.model } : {}),
 		};
 	}
-	if (!isSessionId(normalized)) return null;
-	const meta = await readSessionMeta(cwd, normalized);
-	if (!meta) return null;
-	return {
-		kind: "session",
-		sessionId: normalized,
-		...(meta.model ? { model: meta.model } : {}),
-	};
+	const conversation = (await conversationStore.list()).find(
+		(candidate) =>
+			candidate.threadId === normalized || candidate.sessionId === normalized,
+	);
+	if (conversation) {
+		return conversationBootstrap(conversation);
+	}
+	return null;
 }
 
 export function isLocalResumeId(id: string): boolean {
@@ -97,4 +94,21 @@ async function readSessionMeta(
 	} catch {
 		return null;
 	}
+}
+
+function conversationBootstrap(conversation: {
+	threadId: string;
+	sessionId: string;
+	provider: ModelRef["provider"];
+	model: string;
+}): LocalResumeBootstrap {
+	return {
+		kind: "byok",
+		threadId: conversation.threadId,
+		sessionId: conversation.sessionId,
+		model: {
+			provider: conversation.provider,
+			model: conversation.model,
+		},
+	};
 }

--- a/src/core/session/ResumeBootstrap.ts
+++ b/src/core/session/ResumeBootstrap.ts
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import { type ModelRef, parseModel } from "../../config/defaults.ts";
+import { qSessionDir } from "../../config/paths.ts";
+import { ByokConversationStore } from "../../providers/byok/ByokConversationStore.ts";
+import { isByokThreadId, isSessionId } from "../../utils/id.ts";
+import { sessionPathsForRoot } from "./SessionStore.ts";
+
+export interface LocalResumeBootstrap {
+	kind: "byok" | "session";
+	sessionId: string;
+	threadId?: string;
+	model?: ModelRef;
+}
+
+/**
+ * Resolves local IDs before authentication. This prevents a missing/wrong
+ * workspace from being misreported as a need for Backboard SSO.
+ */
+export async function resolveLocalResumeBootstrap(
+	cwd: string,
+	id: string | undefined,
+	sessionIdHint?: string,
+): Promise<LocalResumeBootstrap | null> {
+	const normalized = id?.trim();
+	if (!normalized || !isLocalResumeId(normalized)) return null;
+	const conversationStore = new ByokConversationStore(cwd);
+	const likelySessionId = isSessionId(normalized) ? normalized : sessionIdHint;
+	const directConversation = likelySessionId
+		? await conversationStore.getAtSessionRoot(
+				qSessionDir(cwd, likelySessionId),
+				isByokThreadId(normalized) ? normalized : undefined,
+			)
+		: null;
+	const conversation =
+		directConversation ??
+		(await conversationStore.list()).find(
+			(candidate) =>
+				candidate.threadId === normalized || candidate.sessionId === normalized,
+		);
+	if (conversation) {
+		return {
+			kind: "byok",
+			threadId: conversation.threadId,
+			sessionId: conversation.sessionId,
+			model: {
+				provider: conversation.provider,
+				model: conversation.model,
+			},
+		};
+	}
+	if (!isSessionId(normalized)) return null;
+	const meta = await readSessionMeta(cwd, normalized);
+	if (!meta) return null;
+	return {
+		kind: "session",
+		sessionId: normalized,
+		...(meta.model ? { model: meta.model } : {}),
+	};
+}
+
+export function isLocalResumeId(id: string): boolean {
+	return isByokThreadId(id) || isSessionId(id);
+}
+
+export function isRemoteResumeId(id: string | undefined): boolean {
+	const normalized = id?.trim();
+	return Boolean(normalized && !isLocalResumeId(normalized));
+}
+
+async function readSessionMeta(
+	cwd: string,
+	sessionId: string,
+): Promise<{ model?: ModelRef } | null> {
+	try {
+		const value = JSON.parse(
+			await readFile(
+				sessionPathsForRoot(qSessionDir(cwd, sessionId)).meta,
+				"utf8",
+			),
+		) as unknown;
+		if (
+			typeof value !== "object" ||
+			value === null ||
+			!("sessionId" in value) ||
+			value.sessionId !== sessionId
+		) {
+			return null;
+		}
+		if ("model" in value && typeof value.model === "string") {
+			try {
+				return { model: parseModel(value.model) };
+			} catch {
+				return {};
+			}
+		}
+		return {};
+	} catch {
+		return null;
+	}
+}

--- a/src/core/session/ResumeIndex.ts
+++ b/src/core/session/ResumeIndex.ts
@@ -1,8 +1,9 @@
-import { mkdir, readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { qUserConfigDir } from "../../config/paths.ts";
 import { acquireFileLease } from "../../utils/FileLease.ts";
-import { writePrivateFileAtomic } from "../../utils/fs.ts";
+import { ensureDir, writePrivateFileAtomic } from "../../utils/fs.ts";
+import { isSessionId } from "../../utils/id.ts";
 
 const RESUME_INDEX_VERSION = 1;
 const RESUME_INDEX_FILE = "session-index.json";
@@ -38,8 +39,15 @@ export async function registerResumeIds(
 	},
 	homeDir?: string,
 ): Promise<void> {
+	if (!isSessionId(input.sessionId)) {
+		throw new Error(`Invalid local session ID: ${input.sessionId}`);
+	}
+	const requestedThreadId = input.threadId?.trim() || undefined;
+	if (input.threadId !== undefined && input.threadId !== null) {
+		if (!requestedThreadId) throw new Error("Thread ID cannot be empty.");
+	}
 	const path = resumeIndexPath(homeDir);
-	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	await ensureDir(dirname(path), 0o700);
 	const lease = await acquireFileLease(`${path}${RESUME_INDEX_LEASE_SUFFIX}`, {
 		label: "session resume index",
 		timeoutMs: 5_000,
@@ -48,14 +56,32 @@ export async function registerResumeIds(
 	});
 	try {
 		const file = await readResumeIndex(homeDir);
+		const existing = file.entries[input.sessionId];
+		const threadId = requestedThreadId ?? existing?.threadId;
+		const previousOwner = threadId ? file.entries[threadId] : undefined;
+		if (
+			previousOwner &&
+			previousOwner.sessionId !== input.sessionId &&
+			file.entries[previousOwner.sessionId]?.threadId === threadId
+		) {
+			const previousSession = file.entries[previousOwner.sessionId];
+			if (previousSession) {
+				const { threadId: _previousThreadId, ...localOnlyEntry } =
+					previousSession;
+				file.entries[previousOwner.sessionId] = localOnlyEntry;
+			}
+		}
 		const entry: ResumeIndexEntry = {
 			cwd: resolve(input.cwd),
 			sessionId: input.sessionId,
-			...(input.threadId ? { threadId: input.threadId } : {}),
+			...(threadId ? { threadId } : {}),
 			updatedAt: new Date().toISOString(),
 		};
+		if (existing?.threadId && existing.threadId !== threadId) {
+			delete file.entries[existing.threadId];
+		}
 		file.entries[input.sessionId] = entry;
-		if (input.threadId) file.entries[input.threadId] = entry;
+		if (threadId) file.entries[threadId] = entry;
 		await writeResumeIndex(path, file);
 	} finally {
 		await lease.release();
@@ -84,7 +110,7 @@ async function readResumeIndex(homeDir?: string): Promise<ResumeIndexFile> {
 		}
 		const entries: Record<string, ResumeIndexEntry> = {};
 		for (const [id, entry] of Object.entries(value.entries)) {
-			if (isResumeIndexEntry(entry)) entries[id] = entry;
+			if (isResumeIndexEntry(id, entry)) entries[id] = entry;
 		}
 		return { version: RESUME_INDEX_VERSION, entries };
 	} catch {
@@ -103,18 +129,32 @@ function emptyIndex(): ResumeIndexFile {
 	return { version: RESUME_INDEX_VERSION, entries: {} };
 }
 
-function isResumeIndexEntry(value: unknown): value is ResumeIndexEntry {
-	return (
+function isResumeIndexEntry(
+	id: string,
+	value: unknown,
+): value is ResumeIndexEntry {
+	if (
 		typeof value === "object" &&
 		value !== null &&
 		"cwd" in value &&
 		typeof value.cwd === "string" &&
+		isAbsolute(value.cwd) &&
 		"sessionId" in value &&
 		typeof value.sessionId === "string" &&
+		isSessionId(value.sessionId) &&
 		"updatedAt" in value &&
 		typeof value.updatedAt === "string" &&
 		(!("threadId" in value) ||
 			value.threadId === undefined ||
 			typeof value.threadId === "string")
-	);
+	) {
+		const threadId =
+			"threadId" in value && typeof value.threadId === "string"
+				? value.threadId
+				: undefined;
+		return isSessionId(id)
+			? id === value.sessionId
+			: threadId !== undefined && threadId.length > 0 && id === threadId;
+	}
+	return false;
 }

--- a/src/core/session/ResumeIndex.ts
+++ b/src/core/session/ResumeIndex.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { qUserConfigDir } from "../../config/paths.ts";
 import { acquireFileLease } from "../../utils/FileLease.ts";
 import { ensureDir, writePrivateFileAtomic } from "../../utils/fs.ts";
-import { isSessionId } from "../../utils/id.ts";
+import { isByokThreadId, isSessionId } from "../../utils/id.ts";
 
 const RESUME_INDEX_VERSION = 1;
 const RESUME_INDEX_FILE = "session-index.json";
@@ -58,7 +58,8 @@ export async function registerResumeIds(
 		const file = await readResumeIndex(homeDir);
 		const existing = file.entries[input.sessionId];
 		const threadId = requestedThreadId ?? existing?.threadId;
-		const previousOwner = threadId ? file.entries[threadId] : undefined;
+		const previousOwner =
+			threadId && isByokThreadId(threadId) ? file.entries[threadId] : undefined;
 		if (
 			previousOwner &&
 			previousOwner.sessionId !== input.sessionId &&
@@ -81,7 +82,7 @@ export async function registerResumeIds(
 			delete file.entries[existing.threadId];
 		}
 		file.entries[input.sessionId] = entry;
-		if (threadId) file.entries[threadId] = entry;
+		if (threadId && isByokThreadId(threadId)) file.entries[threadId] = entry;
 		await writeResumeIndex(path, file);
 	} finally {
 		await lease.release();
@@ -154,7 +155,7 @@ function isResumeIndexEntry(
 				: undefined;
 		return isSessionId(id)
 			? id === value.sessionId
-			: threadId !== undefined && threadId.length > 0 && id === threadId;
+			: threadId !== undefined && isByokThreadId(id) && id === threadId;
 	}
 	return false;
 }

--- a/src/core/session/ResumeIndex.ts
+++ b/src/core/session/ResumeIndex.ts
@@ -1,0 +1,120 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { qUserConfigDir } from "../../config/paths.ts";
+import { acquireFileLease } from "../../utils/FileLease.ts";
+import { writePrivateFileAtomic } from "../../utils/fs.ts";
+
+const RESUME_INDEX_VERSION = 1;
+const RESUME_INDEX_FILE = "session-index.json";
+const RESUME_INDEX_LEASE_SUFFIX = ".lock";
+
+export interface ResumeIndexEntry {
+	cwd: string;
+	sessionId: string;
+	threadId?: string;
+	updatedAt: string;
+}
+
+interface ResumeIndexFile {
+	version: typeof RESUME_INDEX_VERSION;
+	entries: Record<string, ResumeIndexEntry>;
+}
+
+export async function lookupResumeEntry(
+	id: string,
+	homeDir?: string,
+): Promise<ResumeIndexEntry | null> {
+	const normalized = id.trim();
+	if (!normalized) return null;
+	const file = await readResumeIndex(homeDir);
+	return file.entries[normalized] ?? null;
+}
+
+export async function registerResumeIds(
+	input: {
+		cwd: string;
+		sessionId: string;
+		threadId?: string | null;
+	},
+	homeDir?: string,
+): Promise<void> {
+	const path = resumeIndexPath(homeDir);
+	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	const lease = await acquireFileLease(`${path}${RESUME_INDEX_LEASE_SUFFIX}`, {
+		label: "session resume index",
+		timeoutMs: 5_000,
+		retryMs: 50,
+		invalidOwnerStaleMs: 5_000,
+	});
+	try {
+		const file = await readResumeIndex(homeDir);
+		const entry: ResumeIndexEntry = {
+			cwd: resolve(input.cwd),
+			sessionId: input.sessionId,
+			...(input.threadId ? { threadId: input.threadId } : {}),
+			updatedAt: new Date().toISOString(),
+		};
+		file.entries[input.sessionId] = entry;
+		if (input.threadId) file.entries[input.threadId] = entry;
+		await writeResumeIndex(path, file);
+	} finally {
+		await lease.release();
+	}
+}
+
+export function resumeIndexPath(homeDir?: string): string {
+	return join(qUserConfigDir(homeDir), RESUME_INDEX_FILE);
+}
+
+async function readResumeIndex(homeDir?: string): Promise<ResumeIndexFile> {
+	try {
+		const value = JSON.parse(
+			await readFile(resumeIndexPath(homeDir), "utf8"),
+		) as unknown;
+		if (
+			typeof value !== "object" ||
+			value === null ||
+			!("version" in value) ||
+			value.version !== RESUME_INDEX_VERSION ||
+			!("entries" in value) ||
+			typeof value.entries !== "object" ||
+			value.entries === null
+		) {
+			return emptyIndex();
+		}
+		const entries: Record<string, ResumeIndexEntry> = {};
+		for (const [id, entry] of Object.entries(value.entries)) {
+			if (isResumeIndexEntry(entry)) entries[id] = entry;
+		}
+		return { version: RESUME_INDEX_VERSION, entries };
+	} catch {
+		return emptyIndex();
+	}
+}
+
+async function writeResumeIndex(
+	path: string,
+	file: ResumeIndexFile,
+): Promise<void> {
+	await writePrivateFileAtomic(path, `${JSON.stringify(file, null, 2)}\n`);
+}
+
+function emptyIndex(): ResumeIndexFile {
+	return { version: RESUME_INDEX_VERSION, entries: {} };
+}
+
+function isResumeIndexEntry(value: unknown): value is ResumeIndexEntry {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"cwd" in value &&
+		typeof value.cwd === "string" &&
+		"sessionId" in value &&
+		typeof value.sessionId === "string" &&
+		"updatedAt" in value &&
+		typeof value.updatedAt === "string" &&
+		(!("threadId" in value) ||
+			value.threadId === undefined ||
+			typeof value.threadId === "string")
+	);
+}

--- a/src/core/session/ServerEventLog.ts
+++ b/src/core/session/ServerEventLog.ts
@@ -46,9 +46,13 @@ export class ServerEventLog {
 
 	constructor(
 		private sessionId: string,
-		filePath: string,
+		private filePath: string,
 	) {
 		this.writer = new JsonlWriter(filePath);
+	}
+
+	async initialize(): Promise<void> {
+		this.sequence = await nextJsonlSequence(this.filePath);
 	}
 
 	async activate(sessionId: string, filePath: string): Promise<void> {
@@ -62,6 +66,7 @@ export class ServerEventLog {
 			const sequence = await nextJsonlSequence(filePath);
 			await this.writer.flush();
 			this.sessionId = sessionId;
+			this.filePath = filePath;
 			this.sequence = sequence;
 			this.writer = new JsonlWriter(filePath);
 			this.pendingDuringActivation = null;

--- a/src/core/session/SessionLogActivation.ts
+++ b/src/core/session/SessionLogActivation.ts
@@ -1,0 +1,36 @@
+export interface ActivatableSessionLog {
+	activate(sessionId: string, filePath: string): Promise<void>;
+}
+
+export async function activateSessionLogs(input: {
+	clientLog: ActivatableSessionLog;
+	serverLog: ActivatableSessionLog;
+	next: { sessionId: string; clientLog: string; serverLog: string };
+	previous: { sessionId: string; clientLog: string; serverLog: string };
+}): Promise<void> {
+	try {
+		await input.clientLog.activate(input.next.sessionId, input.next.clientLog);
+		await input.serverLog.activate(input.next.sessionId, input.next.serverLog);
+	} catch (error) {
+		const rollback = await Promise.allSettled([
+			input.clientLog.activate(
+				input.previous.sessionId,
+				input.previous.clientLog,
+			),
+			input.serverLog.activate(
+				input.previous.sessionId,
+				input.previous.serverLog,
+			),
+		]);
+		const rollbackErrors = rollback.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (rollbackErrors.length > 0) {
+			throw new AggregateError(
+				[error, ...rollbackErrors],
+				`Failed to rotate logs to session ${input.next.sessionId} and restore session ${input.previous.sessionId}.`,
+			);
+		}
+		throw error;
+	}
+}

--- a/src/core/session/SessionStore.ts
+++ b/src/core/session/SessionStore.ts
@@ -63,9 +63,13 @@ export class SessionStore {
 	}
 
 	async init(meta: SessionMeta): Promise<void> {
+		await this.open();
+		await writeFile(this.paths.meta, JSON.stringify(meta, null, 2), "utf8");
+	}
+
+	async open(): Promise<void> {
 		await ensureDir(this.paths.root);
 		await ensureDir(this.paths.checkpoints);
 		await ensureDir(this.paths.checkpointObjects);
-		await writeFile(this.paths.meta, JSON.stringify(meta, null, 2), "utf8");
 	}
 }

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
+import { resolve as resolvePath } from "node:path";
 import { render } from "ink";
-import { NO_CREDENTIALS_MESSAGE } from "../config/auth.ts";
+import { NO_CREDENTIALS_MESSAGE, resolveAuth } from "../config/auth.ts";
 import {
 	APP_COMMAND_NAME,
 	APP_DISPLAY_NAME,
@@ -8,6 +9,7 @@ import {
 } from "../config/branding.ts";
 import { Config } from "../config/Config.ts";
 import { parseFlags } from "../config/flags.ts";
+import { buildResumeCommand } from "../config/resumeCommand.ts";
 import { AgentController } from "../core/agent/AgentController.ts";
 import { AttachmentManager } from "../core/attachments/AttachmentManager.ts";
 import { sweepStaleClipboardImages } from "../core/attachments/clipboardImage.ts";
@@ -42,9 +44,19 @@ import {
 } from "../core/permissions/index.ts";
 import { ClientEventLog } from "../core/session/ClientEventLog.ts";
 import { JsonEventStream } from "../core/session/JsonEventStream.ts";
+import {
+	isLocalResumeId,
+	isRemoteResumeId,
+	resolveLocalResumeBootstrap,
+} from "../core/session/ResumeBootstrap.ts";
+import {
+	lookupResumeEntry,
+	registerResumeIds,
+} from "../core/session/ResumeIndex.ts";
 import { ServerEventLog } from "../core/session/ServerEventLog.ts";
 import { Session } from "../core/session/Session.ts";
 import { SessionLifecycle } from "../core/session/SessionLifecycle.ts";
+import { activateSessionLogs } from "../core/session/SessionLogActivation.ts";
 import {
 	SessionStore,
 	sessionPathsForRoot,
@@ -66,6 +78,11 @@ import { palette } from "../ui/theme/palette.ts";
 import { ThemeProvider } from "../ui/theme/ThemeProvider.tsx";
 import { detectTerminalBg } from "../ui/theme/terminalBg.ts";
 import { createTheme, setTheme } from "../ui/theme/theme.ts";
+import {
+	activateResumeTarget,
+	type ResumeTarget,
+	resolveResumeTarget,
+} from "../ui/utils/resumeSession.ts";
 import { errorMessage } from "../utils/errors.ts";
 import { shortId } from "../utils/id.ts";
 import { pluralize } from "../utils/string.ts";
@@ -90,6 +107,7 @@ Options:
   --permission-mode <mode>   manual | acceptEdits | auto (prompt only for risky) | bypass (default: manual)
   --lsp                      Enable language-server diagnostics for this run
   --fresh                    Create a new Backboard assistant/thread for this run (isolated)
+  --resume <id>              Resume a Backboard or local BYOK session
   --login                    Sign in with Backboard
   --logout                   Remove saved Backboard credentials
   --help                     Show this help
@@ -117,10 +135,52 @@ async function main(): Promise<void> {
 	}
 	const interactiveRenderConfig = resolveInteractiveRenderConfig();
 
+	const requestedResume = earlyFlags.resume?.trim();
+	const indexedResume = requestedResume
+		? await lookupResumeEntry(requestedResume)
+		: null;
+	const resumeCwd = resolvePath(
+		earlyFlags.cwd ?? indexedResume?.cwd ?? process.cwd(),
+	);
+	const runtimeArgv =
+		earlyFlags.cwd === undefined && indexedResume
+			? [...argv, "--cwd", resumeCwd]
+			: argv;
+	const localResume = await resolveLocalResumeBootstrap(
+		resumeCwd,
+		earlyFlags.resume,
+		indexedResume?.sessionId,
+	);
+	if (requestedResume && isLocalResumeId(requestedResume) && !localResume) {
+		throw new Error(
+			`Local session "${requestedResume}" was not found in ${resumeCwd}. Run the command from its original workspace or pass --cwd <workspace>.`,
+		);
+	}
+	if (isRemoteResumeId(requestedResume) && resolveAuth().backboard === null) {
+		if (
+			earlyFlags.print !== undefined ||
+			earlyFlags.format === "json" ||
+			!process.stdin.isTTY ||
+			!process.stdout.isTTY
+		) {
+			throw new Error(
+				`Backboard sign-in is required to resume remote session "${requestedResume}".`,
+			);
+		}
+		const didLogin = await runLoginCommand();
+		if (!didLogin) {
+			process.exitCode = 1;
+			return;
+		}
+	}
 	let config: Config;
 	while (true) {
 		try {
-			config = new Config({ argv });
+			config = new Config({
+				argv: runtimeArgv,
+				resumeModel: localResume?.model,
+				allowUnauthenticatedResume: localResume !== null,
+			});
 			break;
 		} catch (err) {
 			const error = err instanceof Error ? err : String(err);
@@ -148,15 +208,23 @@ async function main(): Promise<void> {
 		);
 	}
 
-	const sessionId = shortId("sess");
+	const sessionId = localResume?.sessionId ?? shortId("sess");
 	const store = new SessionStore(sessionId, config.cwd);
-	await store.init({
-		sessionId,
-		createdAt: new Date().toISOString(),
+	if (localResume) {
+		await store.open();
+	} else {
+		await store.init({
+			sessionId,
+			createdAt: new Date().toISOString(),
+			cwd: config.cwd,
+			model: config.modelString,
+			profile: config.profile.name,
+		});
+	}
+	await registerResumeIds({
 		cwd: config.cwd,
-		model: config.modelString,
-		profile: config.profile.name,
-	});
+		sessionId,
+	}).catch(() => undefined);
 
 	const bus = new EventBus();
 	const clientLog = new ClientEventLog(sessionId, store.paths.clientLog);
@@ -329,25 +397,35 @@ async function main(): Promise<void> {
 		checkpoints,
 		store,
 		async (activeSessionId, paths) => {
-			await Promise.all([
-				clientLog.activate(activeSessionId, paths.clientLog).catch((error) =>
-					bus.emit({
-						type: "system:warning",
-						message: `Failed to rotate the client session log: ${errorMessage(error)}`,
-					}),
-				),
-				serverLog.activate(activeSessionId, paths.serverLog).catch((error) =>
-					bus.emit({
-						type: "system:warning",
-						message: `Failed to rotate the server session log: ${errorMessage(error)}`,
-					}),
-				),
-			]);
+			const previous = sessionLifecycle.current();
+			const previousPaths = sessionPathsForRoot(previous.sessionRoot);
+			await activateSessionLogs({
+				clientLog,
+				serverLog,
+				next: {
+					sessionId: activeSessionId,
+					clientLog: paths.clientLog,
+					serverLog: paths.serverLog,
+				},
+				previous: {
+					sessionId: previous.sessionId,
+					clientLog: previousPaths.clientLog,
+					serverLog: previousPaths.serverLog,
+				},
+			});
 			jsonStream?.activate(activeSessionId);
 			hookController.setSessionId(activeSessionId);
 		},
 	);
 	await sessionLifecycle.initialize();
+	const detachResumeIndex = bus.on("session:thread", (event) => {
+		const active = sessionLifecycle.current();
+		void registerResumeIds({
+			cwd: config.cwd,
+			sessionId: active.sessionId,
+			threadId: event.threadId,
+		}).catch(() => undefined);
+	});
 	const controller = new AgentController({
 		config,
 		bus,
@@ -370,6 +448,7 @@ async function main(): Promise<void> {
 	sweepStaleClipboardImages();
 	const flush = async (): Promise<void> => {
 		try {
+			detachResumeIndex();
 			await controller.dispose();
 			await lsp.shutdown();
 			await mcpManager.close();
@@ -382,6 +461,31 @@ async function main(): Promise<void> {
 			await sessionLifecycle.dispose();
 		}
 	};
+	let initialResumeTarget: ResumeTarget | undefined;
+	if (config.flags.resume !== undefined) {
+		try {
+			initialResumeTarget = await resolveResumeTarget(
+				client,
+				config.cwd,
+				config.flags.resume,
+			);
+			await activateResumeTarget(initialResumeTarget, {
+				config,
+				controller,
+				onResumeLocalSession: (id) => sessionLifecycle.resume(id),
+				onWarning: (message) => bus.emit({ type: "system:warning", message }),
+			});
+			const active = sessionLifecycle.current();
+			await registerResumeIds({
+				cwd: config.cwd,
+				sessionId: active.sessionId,
+				threadId: controller.threadId,
+			}).catch(() => undefined);
+		} catch (error) {
+			await flush();
+			throw error;
+		}
+	}
 
 	// Fire SessionStart at init so it runs even for prompt-less sessions.
 	await controller.start();
@@ -429,6 +533,7 @@ async function main(): Promise<void> {
 				client={client}
 				attachments={attachmentManager}
 				startupWarnings={startupWarnings}
+				initialResumeTarget={initialResumeTarget}
 				onLogin={(onDeviceCode) => loginWithBackboardSso({ onDeviceCode })}
 				onLogout={logoutSavedCredentials}
 				onNewSession={() => sessionLifecycle.startNew()}
@@ -445,11 +550,22 @@ async function main(): Promise<void> {
 		maxFps: interactiveRenderConfig.maxFps,
 	});
 
+	let activeId = controller.threadId ?? sessionLifecycle.current().sessionId;
 	try {
 		await instance.waitUntilExit();
 	} finally {
+		activeId = controller.threadId ?? sessionLifecycle.current().sessionId;
+		const active = sessionLifecycle.current();
+		await registerResumeIds({
+			cwd: config.cwd,
+			sessionId: active.sessionId,
+			threadId: controller.threadId,
+		}).catch(() => undefined);
 		await flush();
 	}
+	process.stdout.write(
+		`\nResume this session with: ${buildResumeCommand(argv, activeId, {})}\n`,
+	);
 }
 
 async function runAuthScreen(

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -7,9 +7,15 @@ import {
 	APP_DISPLAY_NAME,
 	APP_VERSION,
 } from "../config/branding.ts";
+import { CliUserError, cliUserErrorMessage } from "../config/CliUserError.ts";
 import { Config } from "../config/Config.ts";
+import { parseOutputFormat } from "../config/defaults.ts";
 import { parseFlags } from "../config/flags.ts";
 import { buildResumeCommand } from "../config/resumeCommand.ts";
+import {
+	isHeadlessInvocation,
+	parseRequestedResume,
+} from "../config/resumePreflight.ts";
 import { AgentController } from "../core/agent/AgentController.ts";
 import { AttachmentManager } from "../core/attachments/AttachmentManager.ts";
 import { sweepStaleClipboardImages } from "../core/attachments/clipboardImage.ts";
@@ -84,7 +90,7 @@ import {
 	resolveResumeTarget,
 } from "../ui/utils/resumeSession.ts";
 import { errorMessage } from "../utils/errors.ts";
-import { shortId } from "../utils/id.ts";
+import { isByokThreadId, shortId } from "../utils/id.ts";
 import { pluralize } from "../utils/string.ts";
 
 const HELP = `${APP_DISPLAY_NAME} · coding agent
@@ -135,7 +141,13 @@ async function main(): Promise<void> {
 	}
 	const interactiveRenderConfig = resolveInteractiveRenderConfig();
 
-	const requestedResume = earlyFlags.resume?.trim();
+	let earlyFormat: ReturnType<typeof parseOutputFormat>;
+	try {
+		earlyFormat = parseOutputFormat(earlyFlags.format ?? "default");
+	} catch (error) {
+		throw new CliUserError(errorMessage(error));
+	}
+	const requestedResume = parseRequestedResume(earlyFlags.resume);
 	const indexedResume = requestedResume
 		? await lookupResumeEntry(requestedResume)
 		: null;
@@ -152,19 +164,19 @@ async function main(): Promise<void> {
 		indexedResume?.sessionId,
 	);
 	if (requestedResume && isLocalResumeId(requestedResume) && !localResume) {
-		throw new Error(
+		throw new CliUserError(
 			`Local session "${requestedResume}" was not found in ${resumeCwd}. Run the command from its original workspace or pass --cwd <workspace>.`,
 		);
 	}
-	if (isRemoteResumeId(requestedResume) && resolveAuth().backboard === null) {
-		if (
-			earlyFlags.print !== undefined ||
-			earlyFlags.format === "json" ||
-			!process.stdin.isTTY ||
-			!process.stdout.isTTY
-		) {
-			throw new Error(
-				`Backboard sign-in is required to resume remote session "${requestedResume}".`,
+	const remoteResumeId = isRemoteResumeId(requestedResume)
+		? requestedResume
+		: indexedResume?.threadId && !isByokThreadId(indexedResume.threadId)
+			? indexedResume.threadId
+			: undefined;
+	if (remoteResumeId && resolveAuth().backboard === null) {
+		if (isHeadlessInvocation(earlyFlags, earlyFormat)) {
+			throw new CliUserError(
+				`Backboard sign-in is required to resume remote session "${remoteResumeId}".`,
 			);
 		}
 		const didLogin = await runLoginCommand();
@@ -184,7 +196,7 @@ async function main(): Promise<void> {
 			break;
 		} catch (err) {
 			const error = err instanceof Error ? err : String(err);
-			if (shouldShowAuthScreen(error, earlyFlags)) {
+			if (shouldShowAuthScreen(error, earlyFlags, earlyFormat)) {
 				const didLogin = await runAuthScreen(interactiveRenderConfig);
 				if (!didLogin) return;
 				continue;
@@ -229,6 +241,9 @@ async function main(): Promise<void> {
 	const bus = new EventBus();
 	const clientLog = new ClientEventLog(sessionId, store.paths.clientLog);
 	const serverLog = new ServerEventLog(sessionId, store.paths.serverLog);
+	if (localResume) {
+		await Promise.all([clientLog.initialize(), serverLog.initialize()]);
+	}
 	clientLog.attach(bus);
 	// A crash mid-/undo leaves its write-ahead marker in the crashed session's
 	// journal, and every launch mints a fresh session dir — so follow the
@@ -286,7 +301,7 @@ async function main(): Promise<void> {
 	// Both --print and --format json run through runHeadless, which has no UI to
 	// answer an input:request. Anything that asks there would hang forever, so
 	// the gate must know there is nobody to prompt.
-	const headless = config.flags.print !== undefined || config.format === "json";
+	const headless = isHeadlessInvocation(config.flags, config.format);
 	const permissions = buildPermissionContext(
 		config.cwd,
 		config.flags.permissionMode,
@@ -468,12 +483,12 @@ async function main(): Promise<void> {
 				client,
 				config.cwd,
 				config.flags.resume,
+				indexedResume,
 			);
 			await activateResumeTarget(initialResumeTarget, {
 				config,
 				controller,
 				onResumeLocalSession: (id) => sessionLifecycle.resume(id),
-				onWarning: (message) => bus.emit({ type: "system:warning", message }),
 			});
 			const active = sessionLifecycle.current();
 			await registerResumeIds({
@@ -539,6 +554,7 @@ async function main(): Promise<void> {
 				onNewSession={() => sessionLifecycle.startNew()}
 				onResumeLocalSession={(sessionId) => sessionLifecycle.resume(sessionId)}
 				onResumeRemoteSession={() => sessionLifecycle.startNew()}
+				getActiveSessionId={() => sessionLifecycle.current().sessionId}
 				onExit={() => {
 					controller.cancel({ clearQueue: true });
 				}}
@@ -611,9 +627,9 @@ function clearTerminalScreen(): void {
 function shouldShowAuthScreen(
 	err: Error | string,
 	flags: ReturnType<typeof parseFlags>,
+	format: ReturnType<typeof parseOutputFormat>,
 ): boolean {
-	if (flags.print !== undefined || flags.format === "json") return false;
-	if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+	if (isHeadlessInvocation(flags, format)) return false;
 
 	const message = errorMessage(err);
 	return (
@@ -734,6 +750,8 @@ main().catch((err) => {
 });
 
 function formatFatalError(err: Error | string): string {
+	const userMessage = cliUserErrorMessage(err);
+	if (userMessage !== null) return userMessage;
 	if (err instanceof BackboardError && err.status === 401) {
 		return [
 			"Backboard rejected BACKBOARD_API_KEY (HTTP 401).",

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -13,6 +13,7 @@ import { parseOutputFormat } from "../config/defaults.ts";
 import { parseFlags } from "../config/flags.ts";
 import { buildResumeCommand } from "../config/resumeCommand.ts";
 import {
+	canPromptForPermissions,
 	isHeadlessInvocation,
 	parseRequestedResume,
 } from "../config/resumePreflight.ts";
@@ -148,20 +149,21 @@ async function main(): Promise<void> {
 		throw new CliUserError(errorMessage(error));
 	}
 	const requestedResume = parseRequestedResume(earlyFlags.resume);
-	const indexedResume = requestedResume
-		? await lookupResumeEntry(requestedResume)
-		: null;
+	const indexedLocalResume =
+		requestedResume && isLocalResumeId(requestedResume)
+			? await lookupResumeEntry(requestedResume)
+			: null;
 	const resumeCwd = resolvePath(
-		earlyFlags.cwd ?? indexedResume?.cwd ?? process.cwd(),
+		earlyFlags.cwd ?? indexedLocalResume?.cwd ?? process.cwd(),
 	);
 	const runtimeArgv =
-		earlyFlags.cwd === undefined && indexedResume
+		earlyFlags.cwd === undefined && indexedLocalResume
 			? [...argv, "--cwd", resumeCwd]
 			: argv;
 	const localResume = await resolveLocalResumeBootstrap(
 		resumeCwd,
 		earlyFlags.resume,
-		indexedResume?.sessionId,
+		indexedLocalResume?.sessionId,
 	);
 	if (requestedResume && isLocalResumeId(requestedResume) && !localResume) {
 		throw new CliUserError(
@@ -170,8 +172,10 @@ async function main(): Promise<void> {
 	}
 	const remoteResumeId = isRemoteResumeId(requestedResume)
 		? requestedResume
-		: indexedResume?.threadId && !isByokThreadId(indexedResume.threadId)
-			? indexedResume.threadId
+		: !localResume &&
+				indexedLocalResume?.threadId &&
+				!isByokThreadId(indexedLocalResume.threadId)
+			? indexedLocalResume.threadId
 			: undefined;
 	if (remoteResumeId && resolveAuth().backboard === null) {
 		if (isHeadlessInvocation(earlyFlags, earlyFormat)) {
@@ -204,6 +208,19 @@ async function main(): Promise<void> {
 			process.stderr.write(`${errorMessage(err)}\n`);
 			process.exit(1);
 		}
+	}
+	const missingResumeBackend =
+		localResume !== null &&
+		(localResume.kind === "byok"
+			? !config.hasProviderKeyFor(config.model.provider)
+			: !config.hasBackendForCurrentModel);
+	if (
+		missingResumeBackend &&
+		isHeadlessInvocation(config.flags, config.format)
+	) {
+		throw new CliUserError(
+			`No backend can serve resumed model ${config.modelString}. Sign in with Backboard or enable its provider key before using --print or --format json.`,
+		);
 	}
 
 	// Rewrites a pre-encryption keys.json in place. Best-effort: a read-only or
@@ -305,7 +322,7 @@ async function main(): Promise<void> {
 	const permissions = buildPermissionContext(
 		config.cwd,
 		config.flags.permissionMode,
-		!headless,
+		canPromptForPermissions(config.flags, config.format),
 	);
 	// Must go through startupWarnings (rendered by App/headless), not a pre-render
 	// bus.emit — the bus has no subscribers yet and doesn't replay.
@@ -317,6 +334,11 @@ async function main(): Promise<void> {
 				]
 			: [];
 	const renderWarnings = headless ? [] : interactiveRenderConfig.warnings;
+	const resumeWarnings = missingResumeBackend
+		? [
+				`Session resumed, but no backend can serve ${config.modelString}. Use /keys, /login, or /model before sending a message.`,
+			]
+		: [];
 	// MCP init warnings (unset env vars, skipped/failed servers) are deliberately
 	// kept out of the startup surface — they cluttered every launch. Server status
 	// is still inspectable via /mcp; only the noisy startup emission is dropped.
@@ -324,6 +346,7 @@ async function main(): Promise<void> {
 		...hookConfig.warnings,
 		...permissionWarnings,
 		...renderWarnings,
+		...resumeWarnings,
 	];
 	for (const warning of startupWarnings) {
 		bus.emit({ type: "system:warning", message: warning });
@@ -483,7 +506,7 @@ async function main(): Promise<void> {
 				client,
 				config.cwd,
 				config.flags.resume,
-				indexedResume,
+				indexedLocalResume,
 			);
 			await activateResumeTarget(initialResumeTarget, {
 				config,
@@ -566,12 +589,12 @@ async function main(): Promise<void> {
 		maxFps: interactiveRenderConfig.maxFps,
 	});
 
-	let activeId = controller.threadId ?? sessionLifecycle.current().sessionId;
+	let activeId = sessionLifecycle.current().sessionId;
 	try {
 		await instance.waitUntilExit();
 	} finally {
-		activeId = controller.threadId ?? sessionLifecycle.current().sessionId;
 		const active = sessionLifecycle.current();
+		activeId = active.sessionId;
 		await registerResumeIds({
 			cwd: config.cwd,
 			sessionId: active.sessionId,

--- a/src/providers/ClientRouter.ts
+++ b/src/providers/ClientRouter.ts
@@ -37,6 +37,18 @@ export interface ClientRouterDeps {
 	hasKeyFor: (provider: string) => boolean;
 }
 
+export class BackendUnavailableError extends Error {
+	readonly model: ModelRef;
+
+	constructor(model: ModelRef) {
+		super(
+			`No backend can serve ${formatModel(model)}. Sign in with Backboard or add a key with /keys.`,
+		);
+		this.name = "BackendUnavailableError";
+		this.model = model;
+	}
+}
+
 /**
  * Routes each request to the backend that can serve it.
  *
@@ -258,9 +270,7 @@ export class ClientRouter implements AgentClient {
 		const source = this.sourceFor(model);
 		const client = source === "byok" ? this.deps.byok : this.backboard();
 		if (!client) {
-			throw new Error(
-				`No backend can serve ${formatModel(model)}. Sign in with Backboard or add a key with /keys.`,
-			);
+			throw new BackendUnavailableError(model);
 		}
 		return client;
 	}

--- a/src/providers/byok/ByokClient.ts
+++ b/src/providers/byok/ByokClient.ts
@@ -68,6 +68,16 @@ export const BYOK_THREAD_METADATA_KEY = "backboard_byok";
 export const BYOK_SESSION_ROOT_METADATA_KEY = "backboard_session_root";
 export const BYOK_SESSION_ID_METADATA_KEY = "backboard_session_id";
 
+export class ByokConversationNotFoundError extends Error {
+	readonly threadId: string;
+
+	constructor(threadId: string) {
+		super(`Saved conversation ${threadId} was not found.`);
+		this.name = "ByokConversationNotFoundError";
+		this.threadId = threadId;
+	}
+}
+
 /**
  * Drives direct vendor APIs behind the same contract as `BackboardClient`.
  *
@@ -548,7 +558,7 @@ export class ByokClient implements AgentClient {
 		const thread = this.threads.get(threadId);
 		if (thread?.durableSession) return liveThread(threadId, thread);
 		if (!thread) {
-			throw new Error(`Saved conversation ${threadId} was not found.`);
+			throw new ByokConversationNotFoundError(threadId);
 		}
 		return liveThread(threadId, thread);
 	}

--- a/src/providers/byok/ByokConversationStore.ts
+++ b/src/providers/byok/ByokConversationStore.ts
@@ -111,7 +111,7 @@ export class ByokConversationStore {
 
 	async getAtSessionRoot(
 		sessionRoot: string,
-		threadId: string,
+		threadId?: string,
 		options: { repairInterruptedToolTurn?: boolean } = {},
 	): Promise<StoredByokConversation | null> {
 		const conversation = await this.readPath(
@@ -120,7 +120,7 @@ export class ByokConversationStore {
 		);
 		if (
 			!conversation ||
-			conversation.threadId !== threadId ||
+			(threadId !== undefined && conversation.threadId !== threadId) ||
 			basename(sessionRoot) !== conversation.sessionId
 		) {
 			return null;

--- a/src/providers/createAgentClient.ts
+++ b/src/providers/createAgentClient.ts
@@ -35,7 +35,6 @@ export function createAgentClient(
 		byok,
 		getModel: () => config.model,
 		hasBackboardAuth: () => config.hasBackboardAuth,
-		hasKeyFor: (provider) =>
-			config.auth.providerKeys.some((entry) => entry.provider === provider),
+		hasKeyFor: (provider) => config.hasProviderKeyFor(provider),
 	});
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -63,18 +63,10 @@ import {
 import { checkForCliUpdate } from "../core/update/updateCheck.ts";
 import type { AgentClient } from "../providers/AgentClient.ts";
 import { fetchModels } from "../providers/backboard/models.ts";
-import {
-	backboardThreadToMessages,
-	threadDisplayTitle,
-} from "../providers/backboard/threads.ts";
 import type {
 	BackboardThread,
 	ModelInfo,
 } from "../providers/backboard/types.ts";
-import {
-	BYOK_SESSION_ID_METADATA_KEY,
-	BYOK_THREAD_METADATA_KEY,
-} from "../providers/byok/ByokClient.ts";
 import { errorMessage } from "../utils/errors.ts";
 import { pluralize } from "../utils/string.ts";
 import {
@@ -168,6 +160,13 @@ import { playCompletionNotification } from "./notify.ts";
 import { theme } from "./theme/theme.ts";
 import { composeSubmissionWithNotes } from "./utils/modelNotes.ts";
 import { refreshCredentials as refreshClientCredentials } from "./utils/refreshCredentials.ts";
+import {
+	activateResumeTarget,
+	hydrateResumeTarget,
+	isAlreadyActiveResume,
+	type ResumeTarget,
+	resolveResumeTarget,
+} from "./utils/resumeSession.ts";
 import { shouldReprintOnSettingsExit } from "./utils/settingsReprint.ts";
 import { startNewSession } from "./utils/startNewSession.ts";
 
@@ -184,6 +183,7 @@ interface Props {
 	checkpoints?: CheckpointManager;
 	attachments: AttachmentManager;
 	startupWarnings: readonly string[];
+	initialResumeTarget?: ResumeTarget;
 	onLogin: (
 		onDeviceCode?: (response: BackboardDeviceCodeResponse) => void,
 	) => Promise<string>;
@@ -268,6 +268,7 @@ export function App({
 	checkpoints,
 	attachments,
 	startupWarnings,
+	initialResumeTarget,
 	onLogin,
 	onLogout,
 	onNewSession,
@@ -301,6 +302,14 @@ export function App({
 		update: updateInfo,
 	};
 	const [mode, setMode] = useState<Mode>("normal");
+	const initialResumeApplied = useRef(false);
+	useEffect(() => {
+		if (!initialResumeTarget || initialResumeApplied.current) return;
+		initialResumeApplied.current = true;
+		agent.hydrateTranscript(initialResumeTarget.messages);
+		setShowBanner(false);
+		agent.notice(`Resumed session: ${initialResumeTarget.displayTitle}`);
+	}, [agent, initialResumeTarget]);
 	const [loadingLabel, setLoadingLabel] = useState("Loading");
 	const [models, setModels] = useState<ModelInfo[]>([]);
 	const refreshCredentials = useCallback((): void => {
@@ -1016,8 +1025,8 @@ export function App({
 		},
 		[agent, config, closeMemorySelector],
 	);
-	const resumeSession = useCallback(
-		async (thread: BackboardThread) => {
+	const applyResumeTarget = useCallback(
+		async (load: () => Promise<ResumeTarget>) => {
 			if (controller.hasActiveWork) {
 				agent.notice(
 					"Finish or cancel the current turn before switching sessions.",
@@ -1027,51 +1036,28 @@ export function App({
 				return;
 			}
 			try {
-				const hydratedThread = await client.getThread(thread.thread_id);
-				const messages = backboardThreadToMessages(hydratedThread);
+				const target = await load();
 				if (controller.hasActiveWork) {
 					throw new Error(
 						"A turn started while the session was loading. Cancel it before resuming.",
 					);
 				}
-				if (hydratedThread.metadata_?.[BYOK_THREAD_METADATA_KEY] === true) {
-					const sessionId =
-						hydratedThread.metadata_?.[BYOK_SESSION_ID_METADATA_KEY];
-					if (typeof sessionId !== "string" || sessionId.length === 0) {
-						throw new Error(
-							"Saved BYOK session is missing its local session id.",
-						);
-					}
-					await onResumeLocalSession(sessionId);
-					const provider = hydratedThread.metadata_?.model_provider;
-					const model = hydratedThread.metadata_?.model_name;
-					if (typeof provider === "string" && typeof model === "string") {
-						config.setModel({ provider, model });
-						agent.setModelLabel(`${provider}/${model}`);
-						controller.setModelContextLimit(null);
-						await config.saveRuntimeSelection().catch((error) => {
-							agent.notice(
-								`Session resumed, but saving its model failed: ${errorMessage(error)}`,
-								"error",
-							);
-						});
-					}
-				} else {
-					await onResumeRemoteSession();
-				}
-				if (stdout.isTTY) write(CLEAR_VISIBLE_SCREEN);
-				controller.hydrateSession({
-					threadId: hydratedThread.thread_id,
-					assistantId: hydratedThread.assistant_id,
-					messages,
+				await activateResumeTarget(target, {
+					config,
+					controller,
+					onResumeLocalSession,
+					onResumeRemoteSession,
+					onWarning: (message) => agent.notice(message, "error"),
 				});
-				agent.hydrateTranscript(messages);
-				const visibleMessages = messages.filter(
+				if (stdout.isTTY) write(CLEAR_VISIBLE_SCREEN);
+				agent.setModelLabel(config.modelString);
+				agent.hydrateTranscript(target.messages);
+				const visibleMessages = target.messages.filter(
 					(message) =>
 						message.role !== "assistant" || message.text.trim().length > 0,
 				).length;
 				agent.notice(
-					`Resumed session: ${threadDisplayTitle(hydratedThread)} · ${visibleMessages} ${pluralize(visibleMessages, "message")}`,
+					`Resumed session: ${target.displayTitle} · ${visibleMessages} ${pluralize(visibleMessages, "message")}`,
 				);
 				setShowBanner(false);
 				setMode("normal");
@@ -1085,7 +1071,6 @@ export function App({
 		},
 		[
 			agent,
-			client,
 			config,
 			controller,
 			onResumeLocalSession,
@@ -1093,6 +1078,24 @@ export function App({
 			stdout,
 			write,
 		],
+	);
+	const resumeSession = useCallback(
+		(thread: BackboardThread) =>
+			applyResumeTarget(() => hydrateResumeTarget(client, thread)),
+		[applyResumeTarget, client],
+	);
+	const resumeSessionById = useCallback(
+		(id: string) => {
+			if (isAlreadyActiveResume(id, controller.threadId)) {
+				agent.notice("That session is already active.");
+				setMode("normal");
+				return Promise.resolve();
+			}
+			return applyResumeTarget(() =>
+				resolveResumeTarget(client, config.cwd, id),
+			);
+		},
+		[agent, applyResumeTarget, client, config.cwd, controller.threadId],
 	);
 
 	const performRestore = useCallback(
@@ -1538,7 +1541,13 @@ export function App({
 					openSkillsSelector();
 					break;
 				case "sessions":
-					openSessionsSelector();
+					if (command.id) {
+						setLoadingLabel("Resuming session");
+						setMode("loading");
+						void resumeSessionById(command.id);
+					} else {
+						openSessionsSelector();
+					}
 					break;
 				case "notify": {
 					const next = !config.isNotifyEnabled;
@@ -1665,6 +1674,7 @@ export function App({
 			persistVerbose,
 			quit,
 			refreshMcpStatuses,
+			resumeSessionById,
 			running,
 			sessionEnded,
 			skillController,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -310,9 +310,12 @@ export function App({
 		if (!initialResumeTarget || initialResumeApplied.current) return;
 		initialResumeApplied.current = true;
 		agent.hydrateTranscript(initialResumeTarget.messages);
+		for (const warning of startupWarnings) {
+			agent.notice(warning, "info");
+		}
 		setShowBanner(false);
 		agent.notice(`Resumed session: ${initialResumeTarget.displayTitle}`);
-	}, [agent, initialResumeTarget]);
+	}, [agent, initialResumeTarget, startupWarnings]);
 	const [loadingLabel, setLoadingLabel] = useState("Loading");
 	const [models, setModels] = useState<ModelInfo[]>([]);
 	const refreshCredentials = useCallback((): void => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -50,6 +50,7 @@ import {
 	formatMcpResourceForUser,
 	resourceTemplateVariables,
 } from "../core/mcp/index.ts";
+import { lookupResumeEntry } from "../core/session/ResumeIndex.ts";
 import type {
 	SkillController,
 	SkillInstallTarget,
@@ -191,6 +192,7 @@ interface Props {
 	onNewSession: () => Promise<void>;
 	onResumeLocalSession: (sessionId: string) => Promise<void>;
 	onResumeRemoteSession: () => Promise<void>;
+	getActiveSessionId: () => string;
 	onExit: () => void;
 }
 
@@ -274,6 +276,7 @@ export function App({
 	onNewSession,
 	onResumeLocalSession,
 	onResumeRemoteSession,
+	getActiveSessionId,
 	onExit,
 }: Props): React.ReactElement {
 	const app = useApp();
@@ -1047,7 +1050,6 @@ export function App({
 					controller,
 					onResumeLocalSession,
 					onResumeRemoteSession,
-					onWarning: (message) => agent.notice(message, "error"),
 				});
 				if (stdout.isTTY) write(CLEAR_VISIBLE_SCREEN);
 				agent.setModelLabel(config.modelString);
@@ -1086,16 +1088,30 @@ export function App({
 	);
 	const resumeSessionById = useCallback(
 		(id: string) => {
-			if (isAlreadyActiveResume(id, controller.threadId)) {
+			if (
+				isAlreadyActiveResume(id, controller.threadId, getActiveSessionId())
+			) {
 				agent.notice("That session is already active.");
 				setMode("normal");
 				return Promise.resolve();
 			}
-			return applyResumeTarget(() =>
-				resolveResumeTarget(client, config.cwd, id),
+			return applyResumeTarget(async () =>
+				resolveResumeTarget(
+					client,
+					config.cwd,
+					id,
+					await lookupResumeEntry(id),
+				),
 			);
 		},
-		[agent, applyResumeTarget, client, config.cwd, controller.threadId],
+		[
+			agent,
+			applyResumeTarget,
+			client,
+			config.cwd,
+			controller.threadId,
+			getActiveSessionId,
+		],
 	);
 
 	const performRestore = useCallback(

--- a/src/ui/commands/index.ts
+++ b/src/ui/commands/index.ts
@@ -20,7 +20,7 @@ export type Command =
 	| { type: "discover" }
 	| { type: "hooks" }
 	| { type: "skills" }
-	| { type: "sessions" }
+	| { type: "sessions"; id?: string }
 	| { type: "notify" }
 	| { type: "verbose" }
 	| { type: "update" }
@@ -114,7 +114,7 @@ export const SLASH_COMMANDS: readonly SlashCommandDefinition[] = [
 		name: "sessions",
 		type: "sessions",
 		description: "Resume a session",
-		aliases: ["resume", "continue"],
+		aliases: ["session", "resume", "continue"],
 	},
 	{ name: "login", type: "login", description: "Sign in with Backboard" },
 	{
@@ -190,9 +190,14 @@ export function parseCommand(input: string): Command {
 	}
 
 	const withoutSlash = trimmed.slice(1);
-	const name = withoutSlash.split(/\s+/)[0]?.toLowerCase() ?? "";
+	const [rawName = "", ...rawArgs] = withoutSlash.split(/\s+/);
+	const name = rawName.toLowerCase();
 	const definition = findSlashCommand(name);
 	if (definition) {
+		if (definition.type === "sessions") {
+			const id = rawArgs.join(" ").trim();
+			return id ? { type: "sessions", id } : { type: "sessions" };
+		}
 		return { type: definition.type };
 	}
 	// Filepath-like input (e.g. /a/b/c) is not a command; send it as a

--- a/src/ui/components/SessionsSelector.tsx
+++ b/src/ui/components/SessionsSelector.tsx
@@ -7,6 +7,7 @@ import {
 	truncate,
 } from "../../providers/backboard/threads.ts";
 import type { BackboardThread } from "../../providers/backboard/types.ts";
+import { BYOK_SESSION_ID_METADATA_KEY } from "../../providers/byok/ByokClient.ts";
 import { formatClockTime } from "../../utils/time.ts";
 import { Picker, type PickerTab } from "./Picker.tsx";
 
@@ -32,7 +33,7 @@ export function SessionsSelector({
 	);
 }
 
-function sessionTabs(
+export function sessionTabs(
 	threads: readonly BackboardThread[],
 ): PickerTab<BackboardThread>[] {
 	return [
@@ -43,11 +44,21 @@ function sessionTabs(
 				id: thread.thread_id,
 				name: compactSessionTitle(threadDisplayTitle(thread)),
 				description: formatUpdatedAt(threadUpdatedAt(thread)) ?? "",
-				badge: sessionMessageCount(thread),
+				badge: `${compactSessionId(thread.thread_id)} · ${sessionMessageCount(thread)}`,
+				detail: localSessionId(thread),
 				value: thread,
 			})),
 		},
 	];
+}
+
+function compactSessionId(id: string): string {
+	return id.length <= 14 ? id : `${id.slice(0, 11)}…`;
+}
+
+function localSessionId(thread: BackboardThread): string {
+	const value = thread.metadata_?.[BYOK_SESSION_ID_METADATA_KEY];
+	return typeof value === "string" ? value : "";
 }
 
 function sessionMessageCount(thread: BackboardThread): string {

--- a/src/ui/utils/resumeSession.ts
+++ b/src/ui/utils/resumeSession.ts
@@ -1,8 +1,12 @@
 import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { CliUserError } from "../../config/CliUserError.ts";
 import type { Config } from "../../config/Config.ts";
 import { qSessionDir } from "../../config/paths.ts";
+import { parseRequestedResume } from "../../config/resumePreflight.ts";
 import type { AgentController } from "../../core/agent/AgentController.ts";
 import type { Message } from "../../core/session/Message.ts";
+import type { ResumeIndexEntry } from "../../core/session/ResumeIndex.ts";
 import type { AgentClient } from "../../providers/AgentClient.ts";
 import { BackboardError } from "../../providers/backboard/errors.ts";
 import {
@@ -14,7 +18,6 @@ import {
 	BYOK_SESSION_ID_METADATA_KEY,
 	BYOK_THREAD_METADATA_KEY,
 } from "../../providers/byok/ByokClient.ts";
-import { errorMessage } from "../../utils/errors.ts";
 import { isByokThreadId, isSessionId } from "../../utils/id.ts";
 
 export interface ResumeTarget {
@@ -29,16 +32,36 @@ interface ActivateResumeTargetOptions {
 	controller: AgentController;
 	onResumeLocalSession: (sessionId: string) => Promise<void>;
 	onResumeRemoteSession?: () => Promise<void>;
-	onWarning?: (message: string) => void;
 }
 
 export async function resolveResumeTarget(
 	client: AgentClient,
 	cwd: string,
 	id: string,
+	indexedResume: ResumeIndexEntry | null = null,
 ): Promise<ResumeTarget> {
-	const normalized = id.trim();
-	if (!normalized) throw new Error("A session ID is required.");
+	const normalized = parseRequestedResume(id);
+
+	if (isSessionId(normalized)) {
+		if (
+			indexedResume?.threadId &&
+			resolve(indexedResume.cwd) === resolve(cwd)
+		) {
+			try {
+				const target = resumeTargetFromHydratedThread(
+					await client.getThread(indexedResume.threadId),
+				);
+				return { ...target, localSessionId: normalized };
+			} catch (error) {
+				if (!(error instanceof BackboardError) || error.status !== 404) {
+					throw error;
+				}
+				throw new CliUserError(
+					`Backboard session "${indexedResume.threadId}" was not found for local session "${normalized}".`,
+				);
+			}
+		}
+	}
 
 	if (!isByokThreadId(normalized) && !isSessionId(normalized)) {
 		try {
@@ -70,7 +93,7 @@ export async function resolveResumeTarget(
 		};
 	}
 
-	throw new Error(`Session "${normalized}" was not found.`);
+	throw new CliUserError(`Session "${normalized}" was not found.`);
 }
 
 export async function hydrateResumeTarget(
@@ -92,7 +115,9 @@ function resumeTargetFromHydratedThread(
 		byok &&
 		(typeof localSessionId !== "string" || !isSessionId(localSessionId))
 	) {
-		throw new Error("Saved BYOK session is missing its local session id.");
+		throw new CliUserError(
+			"Saved BYOK session is missing its local session id.",
+		);
 	}
 	return {
 		displayTitle: threadDisplayTitle(hydrated),
@@ -124,11 +149,6 @@ export async function activateResumeTarget(
 		if (typeof provider === "string" && typeof model === "string") {
 			options.config.setModel({ provider, model });
 			options.controller.setModelContextLimit(null);
-			await options.config.saveRuntimeSelection().catch((error) => {
-				options.onWarning?.(
-					`Session resumed, but saving its model failed: ${errorMessage(error)}`,
-				);
-			});
 		}
 	}
 
@@ -142,8 +162,10 @@ export async function activateResumeTarget(
 export function isAlreadyActiveResume(
 	id: string,
 	activeThreadId: string | null,
+	activeSessionId?: string,
 ): boolean {
-	return activeThreadId !== null && id.trim() === activeThreadId;
+	const normalized = id.trim();
+	return normalized === activeThreadId || normalized === activeSessionId;
 }
 
 async function isDirectory(path: string): Promise<boolean> {

--- a/src/ui/utils/resumeSession.ts
+++ b/src/ui/utils/resumeSession.ts
@@ -1,0 +1,155 @@
+import { stat } from "node:fs/promises";
+import type { Config } from "../../config/Config.ts";
+import { qSessionDir } from "../../config/paths.ts";
+import type { AgentController } from "../../core/agent/AgentController.ts";
+import type { Message } from "../../core/session/Message.ts";
+import type { AgentClient } from "../../providers/AgentClient.ts";
+import { BackboardError } from "../../providers/backboard/errors.ts";
+import {
+	backboardThreadToMessages,
+	threadDisplayTitle,
+} from "../../providers/backboard/threads.ts";
+import type { BackboardThread } from "../../providers/backboard/types.ts";
+import {
+	BYOK_SESSION_ID_METADATA_KEY,
+	BYOK_THREAD_METADATA_KEY,
+} from "../../providers/byok/ByokClient.ts";
+import { errorMessage } from "../../utils/errors.ts";
+import { isByokThreadId, isSessionId } from "../../utils/id.ts";
+
+export interface ResumeTarget {
+	displayTitle: string;
+	thread: BackboardThread | null;
+	messages: Message[];
+	localSessionId: string | null;
+}
+
+interface ActivateResumeTargetOptions {
+	config: Config;
+	controller: AgentController;
+	onResumeLocalSession: (sessionId: string) => Promise<void>;
+	onResumeRemoteSession?: () => Promise<void>;
+	onWarning?: (message: string) => void;
+}
+
+export async function resolveResumeTarget(
+	client: AgentClient,
+	cwd: string,
+	id: string,
+): Promise<ResumeTarget> {
+	const normalized = id.trim();
+	if (!normalized) throw new Error("A session ID is required.");
+
+	if (!isByokThreadId(normalized) && !isSessionId(normalized)) {
+		try {
+			return resumeTargetFromHydratedThread(await client.getThread(normalized));
+		} catch (error) {
+			if (!(error instanceof BackboardError) || error.status !== 404) {
+				throw error;
+			}
+		}
+	}
+
+	const threads = await client.listThreads();
+	const listed = threads.find(
+		(thread) =>
+			thread.thread_id === normalized ||
+			thread.metadata_?.[BYOK_SESSION_ID_METADATA_KEY] === normalized,
+	);
+	if (listed) return hydrateResumeTarget(client, listed);
+
+	if (
+		isSessionId(normalized) &&
+		(await isDirectory(qSessionDir(cwd, normalized)))
+	) {
+		return {
+			displayTitle: normalized,
+			thread: null,
+			messages: [],
+			localSessionId: normalized,
+		};
+	}
+
+	throw new Error(`Session "${normalized}" was not found.`);
+}
+
+export async function hydrateResumeTarget(
+	client: AgentClient,
+	thread: BackboardThread,
+): Promise<ResumeTarget> {
+	const hydrated = await client.getThread(thread.thread_id);
+	return resumeTargetFromHydratedThread(hydrated);
+}
+
+function resumeTargetFromHydratedThread(
+	hydrated: BackboardThread,
+): ResumeTarget {
+	const byok = hydrated.metadata_?.[BYOK_THREAD_METADATA_KEY] === true;
+	const localSessionId = byok
+		? hydrated.metadata_?.[BYOK_SESSION_ID_METADATA_KEY]
+		: null;
+	if (
+		byok &&
+		(typeof localSessionId !== "string" || !isSessionId(localSessionId))
+	) {
+		throw new Error("Saved BYOK session is missing its local session id.");
+	}
+	return {
+		displayTitle: threadDisplayTitle(hydrated),
+		thread: hydrated,
+		messages: backboardThreadToMessages(hydrated),
+		localSessionId: typeof localSessionId === "string" ? localSessionId : null,
+	};
+}
+
+export async function activateResumeTarget(
+	target: ResumeTarget,
+	options: ActivateResumeTargetOptions,
+): Promise<void> {
+	if (target.localSessionId) {
+		await options.onResumeLocalSession(target.localSessionId);
+	} else if (target.thread) {
+		await options.onResumeRemoteSession?.();
+	}
+
+	const thread = target.thread;
+	if (!thread) {
+		options.controller.newThread();
+		return;
+	}
+
+	if (thread.metadata_?.[BYOK_THREAD_METADATA_KEY] === true) {
+		const provider = thread.metadata_?.model_provider;
+		const model = thread.metadata_?.model_name;
+		if (typeof provider === "string" && typeof model === "string") {
+			options.config.setModel({ provider, model });
+			options.controller.setModelContextLimit(null);
+			await options.config.saveRuntimeSelection().catch((error) => {
+				options.onWarning?.(
+					`Session resumed, but saving its model failed: ${errorMessage(error)}`,
+				);
+			});
+		}
+	}
+
+	options.controller.hydrateSession({
+		threadId: thread.thread_id,
+		assistantId: thread.assistant_id,
+		messages: target.messages,
+	});
+}
+
+export function isAlreadyActiveResume(
+	id: string,
+	activeThreadId: string | null,
+): boolean {
+	return activeThreadId !== null && id.trim() === activeThreadId;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch {
+		return false;
+	}
+}

--- a/src/ui/utils/resumeSession.ts
+++ b/src/ui/utils/resumeSession.ts
@@ -17,7 +17,9 @@ import type { BackboardThread } from "../../providers/backboard/types.ts";
 import {
 	BYOK_SESSION_ID_METADATA_KEY,
 	BYOK_THREAD_METADATA_KEY,
+	ByokConversationNotFoundError,
 } from "../../providers/byok/ByokClient.ts";
+import { BackendUnavailableError } from "../../providers/ClientRouter.ts";
 import { isByokThreadId, isSessionId } from "../../utils/id.ts";
 
 export interface ResumeTarget {
@@ -41,6 +43,9 @@ export async function resolveResumeTarget(
 	indexedResume: ResumeIndexEntry | null = null,
 ): Promise<ResumeTarget> {
 	const normalized = parseRequestedResume(id);
+	const hasLocalSession =
+		isSessionId(normalized) &&
+		(await isDirectory(qSessionDir(cwd, normalized)));
 
 	if (isSessionId(normalized)) {
 		if (
@@ -53,12 +58,16 @@ export async function resolveResumeTarget(
 				);
 				return { ...target, localSessionId: normalized };
 			} catch (error) {
-				if (!(error instanceof BackboardError) || error.status !== 404) {
+				if (
+					!hasLocalSession ||
+					(!isMissingResumeThread(error) &&
+						!(error instanceof BackendUnavailableError))
+				) {
 					throw error;
 				}
-				throw new CliUserError(
-					`Backboard session "${indexedResume.threadId}" was not found for local session "${normalized}".`,
-				);
+				if (error instanceof BackendUnavailableError) {
+					return localResumeTarget(normalized);
+				}
 			}
 		}
 	}
@@ -67,9 +76,7 @@ export async function resolveResumeTarget(
 		try {
 			return resumeTargetFromHydratedThread(await client.getThread(normalized));
 		} catch (error) {
-			if (!(error instanceof BackboardError) || error.status !== 404) {
-				throw error;
-			}
+			if (!isMissingResumeThread(error)) throw error;
 		}
 	}
 
@@ -81,16 +88,8 @@ export async function resolveResumeTarget(
 	);
 	if (listed) return hydrateResumeTarget(client, listed);
 
-	if (
-		isSessionId(normalized) &&
-		(await isDirectory(qSessionDir(cwd, normalized)))
-	) {
-		return {
-			displayTitle: normalized,
-			thread: null,
-			messages: [],
-			localSessionId: normalized,
-		};
+	if (isSessionId(normalized) && hasLocalSession) {
+		return localResumeTarget(normalized);
 	}
 
 	throw new CliUserError(`Session "${normalized}" was not found.`);
@@ -146,7 +145,11 @@ export async function activateResumeTarget(
 	if (thread.metadata_?.[BYOK_THREAD_METADATA_KEY] === true) {
 		const provider = thread.metadata_?.model_provider;
 		const model = thread.metadata_?.model_name;
-		if (typeof provider === "string" && typeof model === "string") {
+		if (
+			options.config.flags.model === undefined &&
+			typeof provider === "string" &&
+			typeof model === "string"
+		) {
 			options.config.setModel({ provider, model });
 			options.controller.setModelContextLimit(null);
 		}
@@ -174,4 +177,20 @@ async function isDirectory(path: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function isMissingResumeThread(error: unknown): boolean {
+	return (
+		(error instanceof BackboardError && error.status === 404) ||
+		error instanceof ByokConversationNotFoundError
+	);
+}
+
+function localResumeTarget(sessionId: string): ResumeTarget {
+	return {
+		displayTitle: sessionId,
+		thread: null,
+		messages: [],
+		localSessionId: sessionId,
+	};
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from "node:crypto";
 import {
 	appendFile,
+	chmod,
 	mkdir,
 	readFile,
 	rename,
+	rm,
 	stat,
 	unlink,
+	writeFile,
 } from "node:fs/promises";
 import { dirname } from "node:path";
 
@@ -35,6 +38,22 @@ export async function fileExists(path: string): Promise<boolean> {
 
 export async function readUtf8(path: string): Promise<string> {
 	return readFile(path, "utf8");
+}
+
+export async function writePrivateFileAtomic(
+	path: string,
+	content: string,
+): Promise<void> {
+	const temporary = `${path}.tmp-${process.pid}-${Date.now()}-${randomUUID()}`;
+	try {
+		await writeFile(temporary, content, { mode: 0o600 });
+		await chmod(temporary, 0o600).catch(() => undefined);
+		await renameOverPreservingDestination(temporary, path);
+		await chmod(path, 0o600).catch(() => undefined);
+	} catch (error) {
+		await rm(temporary, { force: true }).catch(() => undefined);
+		throw error;
+	}
 }
 
 export async function fileSize(path: string): Promise<number> {

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -9,6 +9,23 @@ export function shortId(prefix = ""): string {
 	return prefix ? `${prefix}_${id}` : id;
 }
 
+export function isShortId(value: string, prefix: string): boolean {
+	const expectedPrefix = `${prefix}_`;
+	return (
+		value.length === expectedPrefix.length + 8 &&
+		value.toLowerCase().startsWith(expectedPrefix.toLowerCase()) &&
+		/^[a-z0-9]{8}$/i.test(value.slice(expectedPrefix.length))
+	);
+}
+
+export function isSessionId(value: string): boolean {
+	return isShortId(value, "sess");
+}
+
+export function isByokThreadId(value: string): boolean {
+	return isShortId(value, "byok");
+}
+
 let counter = 0;
 export function nextSequence(): number {
 	return counter++;

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -13,8 +13,8 @@ export function isShortId(value: string, prefix: string): boolean {
 	const expectedPrefix = `${prefix}_`;
 	return (
 		value.length === expectedPrefix.length + 8 &&
-		value.toLowerCase().startsWith(expectedPrefix.toLowerCase()) &&
-		/^[a-z0-9]{8}$/i.test(value.slice(expectedPrefix.length))
+		value.startsWith(expectedPrefix) &&
+		/^[0-9a-f]{8}$/.test(value.slice(expectedPrefix.length))
 	);
 }
 

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,3 @@
+export function quotePowerShellString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -658,6 +658,37 @@ describe("Config", () => {
 		expect(parseFlags(["--logout"]).logout).toBe(true);
 	});
 
+	it("parses resume IDs in separated and inline forms", () => {
+		expect(parseFlags(["--resume", "thread_1"]).resume).toBe("thread_1");
+		expect(parseFlags(["--resume=thread_2"]).resume).toBe("thread_2");
+		expect(parseFlags(["--resume"]).resume).toBe("");
+	});
+
+	it("allows a validated BYOK resume to bootstrap without Backboard SSO", async () => {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-config-"));
+		const config = new Config({
+			homeDir,
+			resumeModel: { provider: "anthropic", model: "claude-test" },
+			allowUnauthenticatedResume: true,
+		});
+		expect(config.hasBackboardAuth).toBe(false);
+		expect(config.model).toEqual({
+			provider: "anthropic",
+			model: "claude-test",
+		});
+	});
+
+	it("does not bypass authentication for an unvalidated resume model", async () => {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "cli-config-"));
+		expect(
+			() =>
+				new Config({
+					homeDir,
+					resumeModel: { provider: "anthropic", model: "claude-test" },
+				}),
+		).toThrow("No credentials found");
+	});
+
 	it("defaults LSP off and parses the LSP flag", () => {
 		expect(parseFlags([]).lsp).toBeUndefined();
 		expect(parseFlags(["--lsp"]).lsp).toBe(true);

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -676,6 +676,8 @@ describe("Config", () => {
 			provider: "anthropic",
 			model: "claude-test",
 		});
+		expect(config.hasProviderKeyFor("anthropic")).toBe(false);
+		expect(config.hasBackendForCurrentModel).toBe(false);
 	});
 
 	it("does not bypass authentication for an unvalidated resume model", async () => {

--- a/tests/ProviderStreamConsumer.test.ts
+++ b/tests/ProviderStreamConsumer.test.ts
@@ -158,4 +158,25 @@ describe("ProviderStreamConsumer", () => {
 
 		expect(preserved).toBe(1);
 	});
+
+	it("emits a thread event only when the provider thread changes", async () => {
+		const bus = new EventBus();
+		const session = new Session("sess_test");
+		const threadIds: string[] = [];
+		bus.on("session:thread", (event) => threadIds.push(event.threadId));
+		const consumer = new ProviderStreamConsumer(bus, session);
+
+		await consumer.consumeWithRetry(
+			() =>
+				streamOf([
+					{ kind: "thread", threadId: "thread_1" },
+					{ kind: "thread", threadId: "thread_1" },
+					{ kind: "completed", finalText: "ok" },
+				]),
+			stubAssistant(),
+			new AbortController().signal,
+		);
+
+		expect(threadIds).toEqual(["thread_1"]);
+	});
 });

--- a/tests/ResumeBootstrap.test.ts
+++ b/tests/ResumeBootstrap.test.ts
@@ -90,5 +90,19 @@ describe("resolveLocalResumeBootstrap", () => {
 		expect(isRemoteResumeId("byok_deadbeef")).toBe(false);
 		expect(isRemoteResumeId("sess_deadbeef")).toBe(false);
 		expect(isRemoteResumeId(" ")).toBe(false);
+		expect(isLocalResumeId("SESS_DEADBEEF")).toBe(false);
+		expect(isLocalResumeId("sess_DEADBEEF")).toBe(false);
+		expect(isLocalResumeId("sess_deadbegg")).toBe(false);
+	});
+
+	it("ignores an unsafe indexed session hint", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-bootstrap-"));
+		expect(
+			await resolveLocalResumeBootstrap(
+				cwd,
+				"byok_deadbeef",
+				"../../../../etc",
+			),
+		).toBeNull();
 	});
 });

--- a/tests/ResumeBootstrap.test.ts
+++ b/tests/ResumeBootstrap.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	isLocalResumeId,
+	isRemoteResumeId,
+	resolveLocalResumeBootstrap,
+} from "../src/core/session/ResumeBootstrap.ts";
+import { SessionStore } from "../src/core/session/SessionStore.ts";
+import { ByokConversationStore } from "../src/providers/byok/ByokConversationStore.ts";
+
+describe("resolveLocalResumeBootstrap", () => {
+	it("finds a local BYOK conversation by thread or session ID", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-bootstrap-"));
+		const store = new ByokConversationStore(cwd);
+		await store.save(
+			{
+				version: 1,
+				revision: 0,
+				threadId: "byok_d9c35862",
+				sessionId: "sess_1234abcd",
+				sessionRoot: "",
+				provider: "anthropic",
+				model: "claude-test",
+				systemPrompt: "test",
+				createdAt: "2026-08-18T10:00:00Z",
+				updatedAt: "2026-08-18T10:00:00Z",
+				messages: [],
+			},
+			0,
+		);
+
+		for (const id of ["byok_d9c35862", "sess_1234abcd"]) {
+			expect(await resolveLocalResumeBootstrap(cwd, id)).toEqual({
+				kind: "byok",
+				threadId: "byok_d9c35862",
+				sessionId: "sess_1234abcd",
+				model: { provider: "anthropic", model: "claude-test" },
+			});
+		}
+	});
+
+	it("does not treat a namespaced but unknown ID as a valid resume", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-bootstrap-"));
+		expect(await resolveLocalResumeBootstrap(cwd, "byok_deadbeef")).toBeNull();
+		expect(await resolveLocalResumeBootstrap(cwd, "sess_deadbeef")).toBeNull();
+	});
+
+	it("resolves a local-only session from its metadata", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-bootstrap-"));
+		const session = new SessionStore("sess_deadbeef", cwd);
+		await session.init({
+			sessionId: "sess_deadbeef",
+			createdAt: "2026-08-18T10:00:00Z",
+			cwd,
+			model: "openai/gpt-test",
+			profile: "coding",
+		});
+		expect(await resolveLocalResumeBootstrap(cwd, "sess_deadbeef")).toEqual({
+			kind: "session",
+			sessionId: "sess_deadbeef",
+			model: { provider: "openai", model: "gpt-test" },
+		});
+	});
+
+	it("rejects session metadata owned by a different ID", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-bootstrap-"));
+		const session = new SessionStore("sess_deadbeef", cwd);
+		await session.init({
+			sessionId: "sess_deadbeef",
+			createdAt: "2026-08-18T10:00:00Z",
+			cwd,
+			model: "openai/gpt-test",
+			profile: "coding",
+		});
+		await writeFile(
+			session.paths.meta,
+			JSON.stringify({ sessionId: "sess_attacker", model: "openai/gpt-test" }),
+		);
+		expect(await resolveLocalResumeBootstrap(cwd, "sess_deadbeef")).toBeNull();
+	});
+
+	it("recognizes only standardized local ID shapes", () => {
+		expect(isLocalResumeId("byok_deadbeef")).toBe(true);
+		expect(isLocalResumeId("sess_deadbeef")).toBe(true);
+		expect(isLocalResumeId("thread_remote")).toBe(false);
+		expect(isLocalResumeId("../sess_deadbeef")).toBe(false);
+		expect(isRemoteResumeId("thread_remote")).toBe(true);
+		expect(isRemoteResumeId("byok_deadbeef")).toBe(false);
+		expect(isRemoteResumeId("sess_deadbeef")).toBe(false);
+		expect(isRemoteResumeId(" ")).toBe(false);
+	});
+});

--- a/tests/ResumeCommand.test.ts
+++ b/tests/ResumeCommand.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildResumeCommand,
+	quoteShellArg,
+	withoutResumeFlag,
+} from "../src/config/resumeCommand.ts";
+
+describe("resume command", () => {
+	it("preserves invocation flags and replaces a separated resume ID", () => {
+		expect(
+			buildResumeCommand(
+				["--bypass", "--hi", "--a", "--resume", "old_id"],
+				"thread_new",
+				{ platform: "darwin" },
+			),
+		).toBe("backboard --bypass --hi --a --resume thread_new");
+	});
+
+	it("preserves cwd only when it was present in the original invocation", () => {
+		expect(
+			buildResumeCommand(
+				["--cwd", "/tmp/old project", "--resume=old"],
+				"thread_new",
+				{ platform: "darwin" },
+			),
+		).toBe("backboard --cwd '/tmp/old project' --resume thread_new");
+		expect(buildResumeCommand([], "thread_new", { platform: "darwin" })).toBe(
+			"backboard --resume thread_new",
+		);
+	});
+
+	it("does not discard the next flag when resume has no value", () => {
+		expect(withoutResumeFlag(["--resume", "--lsp"])).toEqual(["--lsp"]);
+	});
+
+	it("quotes embedded apostrophes safely on POSIX shells", () => {
+		expect(quoteShellArg("it's here", "linux")).toBe(`'it'"'"'s here'`);
+	});
+
+	it("quotes PowerShell arguments without expanding variables", () => {
+		expect(quoteShellArg("C:\\work\\$archive", "win32")).toBe(
+			"'C:\\work\\$archive'",
+		);
+		expect(quoteShellArg("it's here", "win32")).toBe("'it''s here'");
+	});
+});

--- a/tests/ResumeIndex.test.ts
+++ b/tests/ResumeIndex.test.ts
@@ -63,15 +63,16 @@ describe("resume index", () => {
 		expect(await lookupResumeEntry("sess_1234abcd", homeDir)).toMatchObject({
 			threadId: "thread_remote",
 		});
+		expect(await lookupResumeEntry("thread_remote", homeDir)).toBeNull();
 	});
 
-	it("clears the previous session owner when a thread alias moves", async () => {
+	it("clears the previous session owner when a BYOK thread alias moves", async () => {
 		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
 		await registerResumeIds(
 			{
 				cwd: "/workspace",
 				sessionId: "sess_11111111",
-				threadId: "thread_remote",
+				threadId: "byok_deadbeef",
 			},
 			homeDir,
 		);
@@ -79,14 +80,14 @@ describe("resume index", () => {
 			{
 				cwd: "/workspace",
 				sessionId: "sess_22222222",
-				threadId: "thread_remote",
+				threadId: "byok_deadbeef",
 			},
 			homeDir,
 		);
 		expect(
 			(await lookupResumeEntry("sess_11111111", homeDir))?.threadId,
 		).toBeUndefined();
-		expect(await lookupResumeEntry("thread_remote", homeDir)).toMatchObject({
+		expect(await lookupResumeEntry("byok_deadbeef", homeDir)).toMatchObject({
 			sessionId: "sess_22222222",
 		});
 	});

--- a/tests/ResumeIndex.test.ts
+++ b/tests/ResumeIndex.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
 	lookupResumeEntry,
 	registerResumeIds,
+	resumeIndexPath,
 } from "../src/core/session/ResumeIndex.ts";
 
 describe("resume index", () => {
@@ -43,6 +44,90 @@ describe("resume index", () => {
 		expect((await lookupResumeEntry("sess_22222222", homeDir))?.cwd).toBe(
 			"/two",
 		);
+	});
+
+	it("preserves the thread mapping during session-only registration", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await registerResumeIds(
+			{
+				cwd: "/workspace",
+				sessionId: "sess_1234abcd",
+				threadId: "thread_remote",
+			},
+			homeDir,
+		);
+		await registerResumeIds(
+			{ cwd: "/workspace", sessionId: "sess_1234abcd" },
+			homeDir,
+		);
+		expect(await lookupResumeEntry("sess_1234abcd", homeDir)).toMatchObject({
+			threadId: "thread_remote",
+		});
+	});
+
+	it("clears the previous session owner when a thread alias moves", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await registerResumeIds(
+			{
+				cwd: "/workspace",
+				sessionId: "sess_11111111",
+				threadId: "thread_remote",
+			},
+			homeDir,
+		);
+		await registerResumeIds(
+			{
+				cwd: "/workspace",
+				sessionId: "sess_22222222",
+				threadId: "thread_remote",
+			},
+			homeDir,
+		);
+		expect(
+			(await lookupResumeEntry("sess_11111111", homeDir))?.threadId,
+		).toBeUndefined();
+		expect(await lookupResumeEntry("thread_remote", homeDir)).toMatchObject({
+			sessionId: "sess_22222222",
+		});
+	});
+
+	it("ignores entries with unsafe session IDs or relative workspaces", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await mkdir(join(homeDir, ".backboard"), { recursive: true });
+		await writeFile(
+			resumeIndexPath(homeDir),
+			JSON.stringify({
+				version: 1,
+				entries: {
+					byok_deadbeef: {
+						cwd: "/workspace",
+						sessionId: "../../../../etc",
+						threadId: "byok_deadbeef",
+						updatedAt: "2026-08-18T10:00:00Z",
+					},
+					sess_1234abcd: {
+						cwd: "relative/workspace",
+						sessionId: "sess_1234abcd",
+						updatedAt: "2026-08-18T10:00:00Z",
+					},
+				},
+			}),
+		);
+		expect(await lookupResumeEntry("byok_deadbeef", homeDir)).toBeNull();
+		expect(await lookupResumeEntry("sess_1234abcd", homeDir)).toBeNull();
+	});
+
+	it("rejects invalid IDs before writing the index", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await expect(
+			registerResumeIds(
+				{ cwd: "/workspace", sessionId: "../../../../etc" },
+				homeDir,
+			),
+		).rejects.toThrow("Invalid local session ID");
+		expect(
+			await readFile(resumeIndexPath(homeDir), "utf8").catch(() => ""),
+		).toBe("");
 	});
 
 	it("ignores missing and malformed index files", async () => {

--- a/tests/ResumeIndex.test.ts
+++ b/tests/ResumeIndex.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	lookupResumeEntry,
+	registerResumeIds,
+} from "../src/core/session/ResumeIndex.ts";
+
+describe("resume index", () => {
+	it("maps both session and thread IDs to their workspace", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await registerResumeIds(
+			{
+				cwd: "./workspace",
+				sessionId: "sess_1234abcd",
+				threadId: "byok_d9c35862",
+			},
+			homeDir,
+		);
+		const expected = {
+			cwd: resolve("./workspace"),
+			sessionId: "sess_1234abcd",
+			threadId: "byok_d9c35862",
+		};
+		expect(await lookupResumeEntry("sess_1234abcd", homeDir)).toMatchObject(
+			expected,
+		);
+		expect(await lookupResumeEntry("byok_d9c35862", homeDir)).toMatchObject(
+			expected,
+		);
+	});
+
+	it("merges concurrent registrations without losing entries", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		await Promise.all([
+			registerResumeIds({ cwd: "/one", sessionId: "sess_11111111" }, homeDir),
+			registerResumeIds({ cwd: "/two", sessionId: "sess_22222222" }, homeDir),
+		]);
+		expect((await lookupResumeEntry("sess_11111111", homeDir))?.cwd).toBe(
+			"/one",
+		);
+		expect((await lookupResumeEntry("sess_22222222", homeDir))?.cwd).toBe(
+			"/two",
+		);
+	});
+
+	it("ignores missing and malformed index files", async () => {
+		const homeDir = await mkdtemp(join(tmpdir(), "resume-index-home-"));
+		expect(await lookupResumeEntry("missing", homeDir)).toBeNull();
+	});
+});

--- a/tests/ResumePreflight.test.ts
+++ b/tests/ResumePreflight.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { CliUserError } from "../src/config/CliUserError.ts";
+import { parseOutputFormat } from "../src/config/defaults.ts";
+import {
+	isHeadlessInvocation,
+	parseRequestedResume,
+} from "../src/config/resumePreflight.ts";
+
+describe("resume preflight", () => {
+	it("rejects a missing resume ID before startup", () => {
+		expect(() => parseRequestedResume("")).toThrow(CliUserError);
+		expect(() => parseRequestedResume("  ")).toThrow(
+			"--resume requires a session ID.",
+		);
+		expect(parseRequestedResume(undefined)).toBeUndefined();
+		expect(parseRequestedResume(" thread_123 ")).toBe("thread_123");
+	});
+
+	it("uses the canonical output format for headless detection", () => {
+		expect(
+			isHeadlessInvocation({}, parseOutputFormat("JSON"), {
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(true);
+		expect(
+			isHeadlessInvocation({}, parseOutputFormat("default"), {
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(false);
+		expect(
+			isHeadlessInvocation({ print: "hello" }, "default", {
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/tests/ResumePreflight.test.ts
+++ b/tests/ResumePreflight.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { CliUserError } from "../src/config/CliUserError.ts";
 import { parseOutputFormat } from "../src/config/defaults.ts";
 import {
+	canPromptForPermissions,
 	isHeadlessInvocation,
 	parseRequestedResume,
 } from "../src/config/resumePreflight.ts";
@@ -35,5 +36,28 @@ describe("resume preflight", () => {
 				stdoutIsTTY: true,
 			}),
 		).toBe(true);
+	});
+
+	it("uses input capability rather than stdout TTY for permission prompts", () => {
+		expect(
+			canPromptForPermissions({}, "default", {
+				stdinIsTTY: true,
+			}),
+		).toBe(true);
+		expect(
+			canPromptForPermissions({}, "default", {
+				stdinIsTTY: false,
+			}),
+		).toBe(false);
+		expect(
+			canPromptForPermissions({ print: "hello" }, "default", {
+				stdinIsTTY: true,
+			}),
+		).toBe(false);
+		expect(
+			canPromptForPermissions({}, "json", {
+				stdinIsTTY: true,
+			}),
+		).toBe(false);
 	});
 });

--- a/tests/ResumeSession.test.ts
+++ b/tests/ResumeSession.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { qSessionDir } from "../src/config/paths.ts";
+import type { AgentClient } from "../src/providers/AgentClient.ts";
+import { BackboardError } from "../src/providers/backboard/errors.ts";
+import type { BackboardThread } from "../src/providers/backboard/types.ts";
+import {
+	BYOK_SESSION_ID_METADATA_KEY,
+	BYOK_THREAD_METADATA_KEY,
+} from "../src/providers/byok/ByokClient.ts";
+import {
+	isAlreadyActiveResume,
+	resolveResumeTarget,
+} from "../src/ui/utils/resumeSession.ts";
+
+describe("resolveResumeTarget", () => {
+	it("resolves a Backboard thread ID", async () => {
+		const thread = savedThread("thread_remote");
+		const target = await resolveResumeTarget(
+			fakeClient([thread]),
+			"/tmp/project",
+			thread.thread_id,
+		);
+		expect(target.thread?.thread_id).toBe("thread_remote");
+		expect(target.localSessionId).toBeNull();
+		expect(target.messages).toHaveLength(1);
+	});
+
+	it("resolves BYOK by either thread or local session ID", async () => {
+		const thread = savedThread("byok_thread", {
+			[BYOK_THREAD_METADATA_KEY]: true,
+			[BYOK_SESSION_ID_METADATA_KEY]: "sess_1234abcd",
+			model_provider: "anthropic",
+			model_name: "claude-test",
+		});
+		const client = fakeClient([thread]);
+		expect(
+			(await resolveResumeTarget(client, "/tmp/project", "byok_thread"))
+				.localSessionId,
+		).toBe("sess_1234abcd");
+		expect(
+			(await resolveResumeTarget(client, "/tmp/project", "sess_1234abcd"))
+				.thread?.thread_id,
+		).toBe("byok_thread");
+	});
+
+	it("resolves a local-only session directory", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const target = await resolveResumeTarget(
+			fakeClient([]),
+			cwd,
+			"sess_deadbeef",
+		);
+		expect(target.thread).toBeNull();
+		expect(target.localSessionId).toBe("sess_deadbeef");
+	});
+
+	it("rejects unknown IDs", async () => {
+		await expect(
+			resolveResumeTarget(fakeClient([]), "/tmp/project", "byok_deadbeef"),
+		).rejects.toThrow('Session "byok_deadbeef" was not found.');
+	});
+
+	it("fetches a remote thread directly when it falls outside the list window", async () => {
+		const thread = savedThread("thread_old");
+		const client = fakeClient([]);
+		client.listThreads = async () => {
+			throw new Error("list should not be called");
+		};
+		client.getThread = async () => thread;
+		expect(
+			(await resolveResumeTarget(client, "/tmp/project", "thread_old")).thread
+				?.thread_id,
+		).toBe("thread_old");
+	});
+
+	it("preserves non-404 failures from direct remote lookup", async () => {
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new Error("network unavailable");
+		};
+		await expect(
+			resolveResumeTarget(client, "/tmp/project", "thread_old"),
+		).rejects.toThrow("network unavailable");
+	});
+
+	it("normalizes remote 404s into the session not-found error", async () => {
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new BackboardError("missing", 404, null);
+		};
+		await expect(
+			resolveResumeTarget(client, "/tmp/project", "thread_old"),
+		).rejects.toThrow('Session "thread_old" was not found.');
+	});
+
+	it("detects direct resume of the already-active thread", () => {
+		expect(isAlreadyActiveResume(" thread_old ", "thread_old")).toBe(true);
+		expect(isAlreadyActiveResume("thread_other", "thread_old")).toBe(false);
+		expect(isAlreadyActiveResume("thread_old", null)).toBe(false);
+	});
+});
+
+function savedThread(
+	threadId: string,
+	metadata?: Record<string, unknown>,
+): BackboardThread {
+	return {
+		thread_id: threadId,
+		title: "Saved work",
+		created_at: "2026-08-17T10:00:00Z",
+		updated_at: "2026-08-18T10:00:00Z",
+		metadata_: metadata,
+		messages: [
+			{
+				message_id: "message_1",
+				role: "user",
+				content: "hello",
+				created_at: "2026-08-17T10:00:00Z",
+			},
+		],
+	};
+}
+
+function fakeClient(threads: BackboardThread[]): AgentClient {
+	return {
+		listThreads: async () => threads,
+		getThread: async (threadId: string) => {
+			const thread = threads.find(
+				(candidate) => candidate.thread_id === threadId,
+			);
+			if (!thread) throw new Error("missing");
+			return thread;
+		},
+	} as AgentClient;
+}

--- a/tests/ResumeSession.test.ts
+++ b/tests/ResumeSession.test.ts
@@ -11,7 +11,9 @@ import type { BackboardThread } from "../src/providers/backboard/types.ts";
 import {
 	BYOK_SESSION_ID_METADATA_KEY,
 	BYOK_THREAD_METADATA_KEY,
+	ByokConversationNotFoundError,
 } from "../src/providers/byok/ByokClient.ts";
+import { BackendUnavailableError } from "../src/providers/ClientRouter.ts";
 import {
 	activateResumeTarget,
 	isAlreadyActiveResume,
@@ -81,6 +83,77 @@ describe("resolveResumeTarget", () => {
 		expect(target.messages).toHaveLength(1);
 	});
 
+	it("falls back to a local session when its indexed remote thread is gone", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new BackboardError("missing", 404, null);
+		};
+		const target = await resolveResumeTarget(client, cwd, "sess_deadbeef", {
+			cwd,
+			sessionId: "sess_deadbeef",
+			threadId: "thread_remote",
+			updatedAt: "2026-08-18T10:00:00Z",
+		});
+		expect(target.thread).toBeNull();
+		expect(target.localSessionId).toBe("sess_deadbeef");
+	});
+
+	it("falls back to a local session when its indexed BYOK thread is gone", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new ByokConversationNotFoundError("byok_deadbeef");
+		};
+		const target = await resolveResumeTarget(client, cwd, "sess_deadbeef", {
+			cwd,
+			sessionId: "sess_deadbeef",
+			threadId: "byok_deadbeef",
+			updatedAt: "2026-08-18T10:00:00Z",
+		});
+		expect(target.thread).toBeNull();
+		expect(target.localSessionId).toBe("sess_deadbeef");
+	});
+
+	it("falls back locally when the indexed backend is unavailable", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new BackendUnavailableError({
+				provider: "anthropic",
+				model: "claude-test",
+			});
+		};
+		const target = await resolveResumeTarget(client, cwd, "sess_deadbeef", {
+			cwd,
+			sessionId: "sess_deadbeef",
+			threadId: "thread_remote",
+			updatedAt: "2026-08-18T10:00:00Z",
+		});
+		expect(target.thread).toBeNull();
+		expect(target.localSessionId).toBe("sess_deadbeef");
+	});
+
+	it("preserves transient indexed-thread failures", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const client = fakeClient([]);
+		client.getThread = async () => {
+			throw new Error("network unavailable");
+		};
+		await expect(
+			resolveResumeTarget(client, cwd, "sess_deadbeef", {
+				cwd,
+				sessionId: "sess_deadbeef",
+				threadId: "thread_remote",
+				updatedAt: "2026-08-18T10:00:00Z",
+			}),
+		).rejects.toThrow("network unavailable");
+	});
+
 	it("rejects unknown IDs", async () => {
 		await expect(
 			resolveResumeTarget(fakeClient([]), "/tmp/project", "byok_deadbeef"),
@@ -145,6 +218,7 @@ describe("resolveResumeTarget", () => {
 			model_name: "claude-test",
 		});
 		const config = {
+			flags: {},
 			setModel: () => {},
 			saveRuntimeSelection: async () => {
 				saved++;
@@ -173,6 +247,46 @@ describe("resolveResumeTarget", () => {
 
 		expect(saved).toBe(0);
 		expect(hydratedThreadIds).toEqual(["byok_deadbeef"]);
+	});
+
+	it("preserves an explicit CLI model while hydrating a BYOK session", async () => {
+		let modelChanges = 0;
+		let contextResets = 0;
+		const thread = savedThread("byok_deadbeef", {
+			[BYOK_THREAD_METADATA_KEY]: true,
+			[BYOK_SESSION_ID_METADATA_KEY]: "*************",
+			model_provider: "anthropic",
+			model_name: "claude-test",
+		});
+		const config = {
+			flags: { model: "openai/gpt-test" },
+			setModel: () => {
+				modelChanges++;
+			},
+		} as unknown as Config;
+		const controller = {
+			setModelContextLimit: () => {
+				contextResets++;
+			},
+			hydrateSession: () => {},
+		} as unknown as AgentController;
+
+		await activateResumeTarget(
+			{
+				displayTitle: "Saved work",
+				thread,
+				messages: [],
+				localSessionId: "sess_1234abcd",
+			},
+			{
+				config,
+				controller,
+				onResumeLocalSession: async () => {},
+			},
+		);
+
+		expect(modelChanges).toBe(0);
+		expect(contextResets).toBe(0);
 	});
 });
 

--- a/tests/ResumeSession.test.ts
+++ b/tests/ResumeSession.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Config } from "../src/config/Config.ts";
 import { qSessionDir } from "../src/config/paths.ts";
+import type { AgentController } from "../src/core/agent/AgentController.ts";
 import type { AgentClient } from "../src/providers/AgentClient.ts";
 import { BackboardError } from "../src/providers/backboard/errors.ts";
 import type { BackboardThread } from "../src/providers/backboard/types.ts";
@@ -11,6 +13,7 @@ import {
 	BYOK_THREAD_METADATA_KEY,
 } from "../src/providers/byok/ByokClient.ts";
 import {
+	activateResumeTarget,
 	isAlreadyActiveResume,
 	resolveResumeTarget,
 } from "../src/ui/utils/resumeSession.ts";
@@ -29,7 +32,7 @@ describe("resolveResumeTarget", () => {
 	});
 
 	it("resolves BYOK by either thread or local session ID", async () => {
-		const thread = savedThread("byok_thread", {
+		const thread = savedThread("byok_deadbeef", {
 			[BYOK_THREAD_METADATA_KEY]: true,
 			[BYOK_SESSION_ID_METADATA_KEY]: "sess_1234abcd",
 			model_provider: "anthropic",
@@ -37,13 +40,13 @@ describe("resolveResumeTarget", () => {
 		});
 		const client = fakeClient([thread]);
 		expect(
-			(await resolveResumeTarget(client, "/tmp/project", "byok_thread"))
+			(await resolveResumeTarget(client, "/tmp/project", "byok_deadbeef"))
 				.localSessionId,
 		).toBe("sess_1234abcd");
 		expect(
 			(await resolveResumeTarget(client, "/tmp/project", "sess_1234abcd"))
 				.thread?.thread_id,
-		).toBe("byok_thread");
+		).toBe("byok_deadbeef");
 	});
 
 	it("resolves a local-only session directory", async () => {
@@ -58,10 +61,36 @@ describe("resolveResumeTarget", () => {
 		expect(target.localSessionId).toBe("sess_deadbeef");
 	});
 
+	it("uses the indexed remote thread when resuming its local session ID", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "resume-session-"));
+		await mkdir(qSessionDir(cwd, "sess_deadbeef"), { recursive: true });
+		const thread = savedThread("thread_remote");
+		const target = await resolveResumeTarget(
+			fakeClient([thread]),
+			cwd,
+			"sess_deadbeef",
+			{
+				cwd,
+				sessionId: "sess_deadbeef",
+				threadId: "thread_remote",
+				updatedAt: "2026-08-18T10:00:00Z",
+			},
+		);
+		expect(target.thread?.thread_id).toBe("thread_remote");
+		expect(target.localSessionId).toBe("sess_deadbeef");
+		expect(target.messages).toHaveLength(1);
+	});
+
 	it("rejects unknown IDs", async () => {
 		await expect(
 			resolveResumeTarget(fakeClient([]), "/tmp/project", "byok_deadbeef"),
 		).rejects.toThrow('Session "byok_deadbeef" was not found.');
+	});
+
+	it("rejects noncanonical local IDs instead of treating them as remote", async () => {
+		await expect(
+			resolveResumeTarget(fakeClient([]), "/tmp/project", "SESS_DEADBEEF"),
+		).rejects.toThrow("Local session IDs must use lowercase");
 	});
 
 	it("fetches a remote thread directly when it falls outside the list window", async () => {
@@ -101,6 +130,49 @@ describe("resolveResumeTarget", () => {
 		expect(isAlreadyActiveResume(" thread_old ", "thread_old")).toBe(true);
 		expect(isAlreadyActiveResume("thread_other", "thread_old")).toBe(false);
 		expect(isAlreadyActiveResume("thread_old", null)).toBe(false);
+		expect(isAlreadyActiveResume("sess_deadbeef", null, "sess_deadbeef")).toBe(
+			true,
+		);
+	});
+
+	it("restores a BYOK model without persisting the global selection", async () => {
+		let saved = 0;
+		const hydratedThreadIds: string[] = [];
+		const thread = savedThread("byok_deadbeef", {
+			[BYOK_THREAD_METADATA_KEY]: true,
+			[BYOK_SESSION_ID_METADATA_KEY]: "sess_1234abcd",
+			model_provider: "anthropic",
+			model_name: "claude-test",
+		});
+		const config = {
+			setModel: () => {},
+			saveRuntimeSelection: async () => {
+				saved++;
+			},
+		} as unknown as Config;
+		const controller = {
+			setModelContextLimit: () => {},
+			hydrateSession: (input: { threadId: string }) => {
+				hydratedThreadIds.push(input.threadId);
+			},
+		} as unknown as AgentController;
+
+		await activateResumeTarget(
+			{
+				displayTitle: "Saved work",
+				thread,
+				messages: [],
+				localSessionId: "sess_1234abcd",
+			},
+			{
+				config,
+				controller,
+				onResumeLocalSession: async () => {},
+			},
+		);
+
+		expect(saved).toBe(0);
+		expect(hydratedThreadIds).toEqual(["byok_deadbeef"]);
 	});
 });
 

--- a/tests/SessionEventLog.test.ts
+++ b/tests/SessionEventLog.test.ts
@@ -87,6 +87,32 @@ describe("switchable session event logs", () => {
 		client.detach();
 	});
 
+	it("continues initial sequence numbers when startup opens an existing session", async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), "session-logs-"));
+		const clientPath = path.join(root, "client.jsonl");
+		const serverPath = path.join(root, "server.jsonl");
+		await writeFile(clientPath, '{"sequence":7}\n', "utf8");
+		await writeFile(serverPath, '{"sequence":4}\n', "utf8");
+		const bus = new EventBus();
+		const client = new ClientEventLog("sess_resumed", clientPath);
+		const server = new ServerEventLog("sess_resumed", serverPath);
+		await Promise.all([client.initialize(), server.initialize()]);
+		client.attach(bus);
+
+		bus.emit({ type: "system:warning", message: "continued" });
+		server.request({
+			endpoint: "/continued",
+			method: "GET",
+			headers: {},
+			body: null,
+		});
+		await Promise.all([client.flush(), server.flush()]);
+
+		expect(await readFile(clientPath, "utf8")).toContain('"sequence":8');
+		expect(await readFile(serverPath, "utf8")).toContain('"sequence":5');
+		client.detach();
+	});
+
 	it("continues after an oversized final JSONL record", async () => {
 		const root = await mkdtemp(path.join(os.tmpdir(), "session-logs-"));
 		const initialClient = path.join(root, "initial-client.jsonl");

--- a/tests/SessionLogActivation.test.ts
+++ b/tests/SessionLogActivation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type ActivatableSessionLog,
+	activateSessionLogs,
+} from "../src/core/session/SessionLogActivation.ts";
+
+describe("activateSessionLogs", () => {
+	it("activates both logs in order", async () => {
+		const calls: string[] = [];
+		const client = recordingLog("client", calls);
+		const server = recordingLog("server", calls);
+		await activateSessionLogs({
+			clientLog: client,
+			serverLog: server,
+			next: nextSession(),
+			previous: previousSession(),
+		});
+		expect(calls).toEqual([
+			"client:sess_next:/next/client",
+			"server:sess_next:/next/server",
+		]);
+	});
+
+	it("restores both logs when one activation fails", async () => {
+		const calls: string[] = [];
+		const client = recordingLog("client", calls);
+		const server = recordingLog("server", calls, "sess_next");
+		await expect(
+			activateSessionLogs({
+				clientLog: client,
+				serverLog: server,
+				next: nextSession(),
+				previous: previousSession(),
+			}),
+		).rejects.toThrow("server failed");
+		expect(calls).toEqual([
+			"client:sess_next:/next/client",
+			"server:sess_next:/next/server",
+			"client:sess_previous:/previous/client",
+			"server:sess_previous:/previous/server",
+		]);
+	});
+
+	it("reports activation and rollback failures together", async () => {
+		const calls: string[] = [];
+		const client = recordingLog("client", calls, "sess_previous");
+		const server = recordingLog("server", calls, "sess_next");
+		await expect(
+			activateSessionLogs({
+				clientLog: client,
+				serverLog: server,
+				next: nextSession(),
+				previous: previousSession(),
+			}),
+		).rejects.toBeInstanceOf(AggregateError);
+	});
+});
+
+function recordingLog(
+	name: string,
+	calls: string[],
+	failSessionId?: string,
+): ActivatableSessionLog {
+	return {
+		async activate(sessionId, filePath) {
+			calls.push(`${name}:${sessionId}:${filePath}`);
+			if (sessionId === failSessionId) {
+				throw new Error(`${name} failed`);
+			}
+		},
+	};
+}
+
+function nextSession() {
+	return {
+		sessionId: "sess_next",
+		clientLog: "/next/client",
+		serverLog: "/next/server",
+	};
+}
+
+function previousSession() {
+	return {
+		sessionId: "sess_previous",
+		clientLog: "/previous/client",
+		serverLog: "/previous/server",
+	};
+}

--- a/tests/SessionsSelector.test.ts
+++ b/tests/SessionsSelector.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import type { BackboardThread } from "../src/providers/backboard/types.ts";
+import { filterItems } from "../src/ui/components/Picker.tsx";
+import { sessionTabs } from "../src/ui/components/SessionsSelector.tsx";
+
+describe("sessionTabs", () => {
+	it("shows one date and a compact ID while keeping full IDs searchable", () => {
+		const thread: BackboardThread = {
+			thread_id: "thread_1234567890abcdef",
+			title: "Resume work",
+			message_count: 4,
+			created_at: "2026-08-17T10:00:00Z",
+			updated_at: "2026-08-18T11:30:00Z",
+			metadata_: { backboard_session_id: "sess_1234abcd" },
+			messages: [],
+		};
+		const item = sessionTabs([thread])[0]?.items[0];
+		if (!item) throw new Error("expected a session picker item");
+		expect(item.status).toBeUndefined();
+		expect(item.description).toContain("8/18");
+		expect(item?.badge).toContain("thread_1234…");
+		expect(item?.badge).toContain("4 msg");
+		expect(filterItems([item], "thread_1234567890abcdef")).toHaveLength(1);
+		expect(filterItems([item], "sess_1234abcd")).toHaveLength(1);
+	});
+});

--- a/tests/UICommands.test.ts
+++ b/tests/UICommands.test.ts
@@ -46,6 +46,12 @@ describe("parseCommand", () => {
 
 	it("parses sessions", () => {
 		expect(parseCommand("/sessions")).toEqual({ type: "sessions" });
+		expect(parseCommand("/session")).toEqual({ type: "sessions" });
+		expect(parseCommand("/resume")).toEqual({ type: "sessions" });
+		expect(parseCommand("/resume thread_123")).toEqual({
+			type: "sessions",
+			id: "thread_123",
+		});
 	});
 
 	it("parses logout", () => {


### PR DESCRIPTION
Supersedes #11, which GitHub would not allow reopening after the head branch was rebased and force-pushed.

## Summary
- add `--resume` startup support and `/resume`, `/session`, and `/sessions` commands for Backboard, BYOK, and local sessions
- generate reusable exit hints that preserve original CLI flags, replace stale resume IDs, and only retain `--cwd` when explicitly supplied
- add a user-level resume index so local IDs reopen their original workspace from any directory without triggering SSO
- improve the session picker with updated time, compact IDs, message counts, and full-ID search
- make resume activation safer with self-resume protection, direct remote hydration, best-effort index persistence, and transactional session-log rotation
- preserve explicit model precedence, avoid remote-ID workspace relocation, and safely handle stale indexed threads
- separate permission prompt capability from auth headlessness and provide clear missing-backend recovery guidance
- share ID, shell quoting, atomic private-file, provider-key, and typed backend-error helpers across the implementation
- rebase the feature onto the latest `main`, including the interactive input rendering changes from #12

## Validation
- `bun run validate`
  - 1,413 passed
  - 3 skipped (`cmd.exe` tests unavailable on macOS)
  - 0 failed
- interactively verified BYOK and local-only resume from arbitrary directories
- interactively verified `/sessions`, `/resume`, direct session switching, self-resume, read-only index behavior, and exit hints with and without explicit `--cwd`
- interactively verified direct resume of a real Backboard thread through active SSO from `/tmp`
- verified headless missing-backend failure and interactive `/keys`, `/login`, or `/model` recovery guidance
