### PR TITLE
Add Backboard.io docs MCP server

### DIFF
--- a/src/core/mcp/catalog.ts
+++ b/src/core/mcp/catalog.ts
@@ -196,6 +196,13 @@ const GENERAL_MCP_SERVERS: readonly McpCatalogServer[] = [
 		description: "Create and manage Supabase projects",
 		url: "https://mcp.supabase.com/mcp",
 	}),
+	remoteServer({
+		name: "backboard-docs",
+		title: "Backboard.io",
+		category: "Project Management & Documentation",
+		description: "Search Backboard documentation",
+		url: "https://backboard-docs.docsalot.dev/api/mcp",
+	}),
 ];
 
 const CLAUDE_REMOTE_MCP_SERVERS: readonly McpCatalogServer[] = [


### PR DESCRIPTION
## Summary
- add the Backboard.io documentation MCP server to the curated R-CLI catalog
- configure the streamable HTTP endpoint at https://backboard-docs.docsalot.dev/api/mcp

## Validation
- `bun run validate`