### PR TITLE
Fix Auto permissions for MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ for details and limitations.
 
 ## Permissions and safe use
 
-R-CLI starts in `manual` permission mode. Read-only operations may run
-automatically; edits, writes, and non-trivial commands ask before running.
+R-CLI starts in `auto` permission mode. Workspace edits, network reads, and
+commands not classified as risky run automatically; risky actions still ask.
 
 Press `Shift+Tab` to cycle interactive permission modes, or choose one at
 startup:
@@ -723,7 +723,7 @@ and untracked work.
 - Do not commit `.env`, API keys, MCP authorization headers, or hook secrets.
 - Review project `.backboard/mcp.json` and `.backboard/hooks.json` files before
   using an unfamiliar repository.
-- Keep the default permission mode until you understand a project's scripts.
+- Use `manual` permission mode when opening an unfamiliar repository.
 - Use `bypass` only in isolated, disposable environments.
 - Report suspected vulnerabilities privately to the Backboard maintainers
   rather than opening a public exploit report.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ for details and limitations.
 
 R-CLI starts in `auto` permission mode. Workspace edits, network reads, and
 commands not classified as risky run automatically; risky actions still ask.
+MCP tools still ask unless the user has explicitly trusted the server's
+read-only annotations.
 
 Press `Shift+Tab` to cycle interactive permission modes, or choose one at
 startup:
@@ -723,6 +725,8 @@ and untracked work.
 - Do not commit `.env`, API keys, MCP authorization headers, or hook secrets.
 - Review project `.backboard/mcp.json` and `.backboard/hooks.json` files before
   using an unfamiliar repository.
+- Review project `.backboard/settings.json`; it can change permission modes and
+  rules for the repository.
 - Use `manual` permission mode when opening an unfamiliar repository.
 - Use `bypass` only in isolated, disposable environments.
 - Report suspected vulnerabilities privately to the Backboard maintainers

--- a/src/core/permissions/PermissionMode.ts
+++ b/src/core/permissions/PermissionMode.ts
@@ -31,7 +31,7 @@ export function isKnownPermissionMode(value: string | undefined): boolean {
 }
 
 export function parsePermissionMode(value: string | undefined): PermissionMode {
-	return isKnownPermissionMode(value) ? (value as PermissionMode) : "manual";
+	return isKnownPermissionMode(value) ? (value as PermissionMode) : "auto";
 }
 
 export function nextPermissionMode(mode: PermissionMode): PermissionMode {

--- a/src/core/permissions/PermissionMode.ts
+++ b/src/core/permissions/PermissionMode.ts
@@ -1,7 +1,7 @@
 /**
  * All permission modes. `auto` allows workspace edits, network reads, and any
  * command off the danger list (see dangerousCommands.ts); dangerous commands
- * and outward-facing tools (browser, computer, mutating MCP) still prompt.
+ * and outward-facing tools (browser, computer, destructive MCP) still prompt.
  */
 export const PERMISSION_MODES = [
 	"manual",

--- a/src/core/permissions/PermissionMode.ts
+++ b/src/core/permissions/PermissionMode.ts
@@ -1,7 +1,7 @@
 /**
  * All permission modes. `auto` allows workspace edits, network reads, and any
  * command off the danger list (see dangerousCommands.ts); dangerous commands
- * and outward-facing tools (browser, computer, destructive MCP) still prompt.
+ * and outward-facing tools (browser, computer, mutating MCP) still prompt.
  */
 export const PERMISSION_MODES = [
 	"manual",
@@ -13,7 +13,7 @@ export const PERMISSION_MODES = [
 export type PermissionMode = (typeof PERMISSION_MODES)[number];
 
 /** Modes reachable by Shift+Tab. `bypass` is flag-only (`--permission-mode`). */
-const CYCLE_MODES = ["manual", "acceptEdits", "auto"] as const;
+const CYCLE_MODES = ["auto", "acceptEdits", "manual"] as const;
 
 const LABELS: Record<PermissionMode, string> = {
 	manual: "Manual",
@@ -31,7 +31,8 @@ export function isKnownPermissionMode(value: string | undefined): boolean {
 }
 
 export function parsePermissionMode(value: string | undefined): PermissionMode {
-	return isKnownPermissionMode(value) ? (value as PermissionMode) : "auto";
+	if (value === undefined) return "auto";
+	return isKnownPermissionMode(value) ? (value as PermissionMode) : "manual";
 }
 
 export function nextPermissionMode(mode: PermissionMode): PermissionMode {

--- a/src/core/permissions/index.ts
+++ b/src/core/permissions/index.ts
@@ -13,7 +13,7 @@ export {
 } from "./PermissionMode.ts";
 export type { PermissionContext } from "./types.ts";
 
-/** Flag > settings mode > "manual". Rules come from .backboard/settings.json. */
+/** Flag > settings mode > "auto". Rules come from .backboard/settings.json. */
 export function buildPermissionContext(
 	cwd: string,
 	flagMode: string | undefined,

--- a/src/core/permissions/index.ts
+++ b/src/core/permissions/index.ts
@@ -24,5 +24,6 @@ export function buildPermissionContext(
 		mode: parsePermissionMode(flagMode ?? settings.mode),
 		rules: parseRuleSet(settings),
 		interactive,
+		warnings: settings.warnings,
 	};
 }

--- a/src/core/permissions/settings.ts
+++ b/src/core/permissions/settings.ts
@@ -14,6 +14,7 @@ export interface PermissionSettings {
 	allow: string[];
 	deny: string[];
 	ask: string[];
+	warnings?: string[];
 }
 
 function settingsPath(cwd: string): string {
@@ -51,11 +52,18 @@ export function loadPermissionSettings(cwd: string): PermissionSettings {
 		deny: stringArray(record.deny),
 		ask: stringArray(record.ask),
 	};
-	if (
-		typeof record.mode === "string" &&
-		(PERMISSION_MODES as readonly string[]).includes(record.mode)
-	) {
-		settings.mode = parsePermissionMode(record.mode);
+	if (record.mode !== undefined) {
+		if (
+			typeof record.mode === "string" &&
+			(PERMISSION_MODES as readonly string[]).includes(record.mode)
+		) {
+			settings.mode = parsePermissionMode(record.mode);
+		} else {
+			settings.mode = "manual";
+			settings.warnings = [
+				`Unknown permissions.mode in ${settingsPath(cwd)}; using manual mode. Valid: ${PERMISSION_MODES.join(", ")}.`,
+			];
+		}
 	}
 	return settings;
 }

--- a/src/core/permissions/types.ts
+++ b/src/core/permissions/types.ts
@@ -27,6 +27,7 @@ export interface PermissionContext {
 	rules: RuleSet;
 	/** False in headless mode and sub-agents: an `ask` auto-denies unless `escalate` yields a prompt. */
 	interactive: boolean;
+	warnings?: string[];
 	escalate?: () => AskUserFn | null;
 	promptHost?: PermissionContext;
 }

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -113,7 +113,7 @@ Options:
   --profile <name>           Profile to load (default: coding)
   --cwd <path>               Working directory
   --print <prompt>           Run a single prompt non-interactively
-  --permission-mode <mode>   manual | acceptEdits | auto (prompt only for risky) | bypass (default: manual)
+  --permission-mode <mode>   manual | acceptEdits | auto (prompt only for risky) | bypass (default: auto)
   --lsp                      Enable language-server diagnostics for this run
   --fresh                    Create a new Backboard assistant/thread for this run (isolated)
   --resume <id>              Resume a Backboard or local BYOK session

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -348,6 +348,7 @@ async function main(): Promise<void> {
 	const startupWarnings = [
 		...config.startupWarnings,
 		...hookConfig.warnings,
+		...(permissions.warnings ?? []),
 		...permissionWarnings,
 		...agentCatalog.warnings,
 		...renderWarnings,

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -93,7 +93,7 @@ export interface AppState {
 
 export function initialState(
 	model: string,
-	permissionMode: PermissionMode = "manual",
+	permissionMode: PermissionMode = "auto",
 ): AppState {
 	return {
 		status: "idle",

--- a/src/tools/FindMcpTool.tsx
+++ b/src/tools/FindMcpTool.tsx
@@ -4,6 +4,10 @@ import type {
 	McpRegistryItem,
 	McpServerRuntimeStatus,
 } from "../core/mcp/index.ts";
+import type {
+	PermissionCheckContext,
+	PermissionDecision,
+} from "../core/permissions/types.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
 import { ok, type ToolResult } from "../core/tools/ToolResult.ts";
@@ -77,6 +81,16 @@ export class FindMcpTool extends Tool<Input, Output> {
 
 	override isConcurrencySafe(): boolean {
 		return false;
+	}
+
+	override checkPermissions(
+		_input: Input,
+		ctx: PermissionCheckContext,
+	): PermissionDecision | undefined {
+		if (ctx.mode === "auto") {
+			return { behavior: "allow", reason: "MCP discovery (auto mode)" };
+		}
+		return undefined;
 	}
 
 	override summarizeInput(input: Input): string | undefined {

--- a/src/tools/FindMcpTool.tsx
+++ b/src/tools/FindMcpTool.tsx
@@ -87,7 +87,7 @@ export class FindMcpTool extends Tool<Input, Output> {
 		_input: Input,
 		ctx: PermissionCheckContext,
 	): PermissionDecision | undefined {
-		if (ctx.mode === "auto") {
+		if (ctx.mode === "auto" && ctx.interactive) {
 			return { behavior: "allow", reason: "MCP discovery (auto mode)" };
 		}
 		return undefined;
@@ -210,10 +210,14 @@ export class FindMcpTool extends Tool<Input, Output> {
 	): Promise<ToolResult<Output>> {
 		// Adding a server needs a human confirm; a sub-agent can't prompt, so
 		// surface the candidate instead of throwing on askUser.
-		if ((ctx.agentDepth ?? 0) > 0) {
+		if ((ctx.agentDepth ?? 0) > 0 || ctx.permissions?.interactive === false) {
+			const reason =
+				(ctx.agentDepth ?? 0) > 0
+					? "a sub-agent cannot prompt"
+					: "this run is non-interactive";
 			return ok(
 				{ task: input.task, candidates: [] },
-				`Found the "${item.title}" MCP server, but adding it must be confirmed by the user and a sub-agent cannot prompt. Ask the main agent to run find_mcp for this task.`,
+				`Found the "${item.title}" MCP server, but adding it must be confirmed by the user and ${reason}. Run find_mcp in an interactive main-agent session for this task.`,
 				"Confirmation needed",
 			);
 		}

--- a/src/tools/FindSkillTool.tsx
+++ b/src/tools/FindSkillTool.tsx
@@ -1,8 +1,4 @@
 import { z } from "zod";
-import type {
-	PermissionCheckContext,
-	PermissionDecision,
-} from "../core/permissions/types.ts";
 import type { Skill } from "../core/skills/Skill.ts";
 import type { SkillsShListItem } from "../core/skills/skillsSh.ts";
 import { Tool } from "../core/tools/Tool.ts";
@@ -96,16 +92,6 @@ export class FindSkillTool extends Tool<Input, Output> {
 
 	override isConcurrencySafe(): boolean {
 		return false;
-	}
-
-	override checkPermissions(
-		_input: Input,
-		ctx: PermissionCheckContext,
-	): PermissionDecision | undefined {
-		if (ctx.mode === "auto") {
-			return { behavior: "allow", reason: "skill discovery (auto mode)" };
-		}
-		return undefined;
 	}
 
 	override summarizeInput(input: Input): string | undefined {
@@ -218,10 +204,14 @@ export class FindSkillTool extends Tool<Input, Output> {
 
 		// A download runs third-party code and needs a human confirm; a sub-agent
 		// can't prompt, so surface the candidate instead of throwing on askUser.
-		if ((ctx.agentDepth ?? 0) > 0) {
+		if ((ctx.agentDepth ?? 0) > 0 || ctx.permissions?.interactive === false) {
+			const reason =
+				(ctx.agentDepth ?? 0) > 0
+					? "a sub-agent cannot prompt"
+					: "this run is non-interactive";
 			return ok(
 				{ task: input.task, candidates: remoteCandidates(ranked) },
-				`Found "${c.slug}" on skills.sh, but downloading a third-party skill must be confirmed by the user and a sub-agent cannot prompt. Ask the main agent to run find_skill for this task.`,
+				`Found "${c.slug}" on skills.sh, but downloading a third-party skill must be confirmed by the user and ${reason}. Run find_skill in an interactive main-agent session for this task.`,
 				"Confirmation needed",
 			);
 		}

--- a/src/tools/FindSkillTool.tsx
+++ b/src/tools/FindSkillTool.tsx
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import type {
+	PermissionCheckContext,
+	PermissionDecision,
+} from "../core/permissions/types.ts";
 import type { Skill } from "../core/skills/Skill.ts";
 import type { SkillsShListItem } from "../core/skills/skillsSh.ts";
 import { Tool } from "../core/tools/Tool.ts";
@@ -92,6 +96,16 @@ export class FindSkillTool extends Tool<Input, Output> {
 
 	override isConcurrencySafe(): boolean {
 		return false;
+	}
+
+	override checkPermissions(
+		_input: Input,
+		ctx: PermissionCheckContext,
+	): PermissionDecision | undefined {
+		if (ctx.mode === "auto") {
+			return { behavior: "allow", reason: "skill discovery (auto mode)" };
+		}
+		return undefined;
 	}
 
 	override summarizeInput(input: Input): string | undefined {

--- a/src/tools/MCPToolAdapter.tsx
+++ b/src/tools/MCPToolAdapter.tsx
@@ -1,9 +1,5 @@
 import { z } from "zod";
 import type { McpCallResult, McpToolDefinition } from "../core/mcp/MCPTypes.ts";
-import type {
-	PermissionCheckContext,
-	PermissionDecision,
-} from "../core/permissions/types.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
@@ -76,20 +72,9 @@ export class McpToolAdapter extends Tool<
 	}
 
 	override isDestructive(_input: Record<string, unknown>): boolean {
-		return this.definition.annotations?.destructiveHint === true;
-	}
-
-	override checkPermissions(
-		input: Record<string, unknown>,
-		ctx: PermissionCheckContext,
-	): PermissionDecision | undefined {
-		if (ctx.mode === "auto" && !this.isDestructive(input)) {
-			return {
-				behavior: "allow",
-				reason: "non-destructive MCP tool (auto mode)",
-			};
-		}
-		return undefined;
+		if (!this.definition.trustAnnotations) return true;
+		if (this.claimsReadOnly()) return false;
+		return this.definition.annotations?.destructiveHint !== false;
 	}
 
 	async execute(

--- a/src/tools/MCPToolAdapter.tsx
+++ b/src/tools/MCPToolAdapter.tsx
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import type { McpCallResult, McpToolDefinition } from "../core/mcp/MCPTypes.ts";
+import type {
+	PermissionCheckContext,
+	PermissionDecision,
+} from "../core/permissions/types.ts";
 import type { OpenAITool } from "../core/tools/schema.ts";
 import { Tool } from "../core/tools/Tool.ts";
 import type { ToolContext } from "../core/tools/ToolContext.ts";
@@ -73,6 +77,19 @@ export class McpToolAdapter extends Tool<
 
 	override isDestructive(_input: Record<string, unknown>): boolean {
 		return this.definition.annotations?.destructiveHint === true;
+	}
+
+	override checkPermissions(
+		input: Record<string, unknown>,
+		ctx: PermissionCheckContext,
+	): PermissionDecision | undefined {
+		if (ctx.mode === "auto" && !this.isDestructive(input)) {
+			return {
+				behavior: "allow",
+				reason: "non-destructive MCP tool (auto mode)",
+			};
+		}
+		return undefined;
 	}
 
 	async execute(

--- a/tests/FindMcpTool.test.ts
+++ b/tests/FindMcpTool.test.ts
@@ -5,6 +5,7 @@ import type {
 	McpRegistryItem,
 	McpServerRuntimeStatus,
 } from "../src/core/mcp/index.ts";
+import { parseRuleSet } from "../src/core/permissions/PermissionRules.ts";
 import type { ToolContext } from "../src/core/tools/ToolContext.ts";
 import {
 	FindMcpTool,
@@ -55,14 +56,22 @@ class FakeMcp implements McpRegistrar {
 	}
 }
 
-function ctx(answer = "Add", depth = 0): ToolContext {
+function ctx(answer = "Add", depth = 0, interactive = true): ToolContext {
 	return {
 		sessionId: "t",
 		cwd: "/tmp",
 		bus: new EventBus(),
 		signal: new AbortController().signal,
-		askUser: async () => answer,
+		askUser: async () => {
+			if (!interactive) throw new Error("unexpected prompt");
+			return answer;
+		},
 		agentDepth: depth,
+		permissions: {
+			mode: "auto",
+			rules: parseRuleSet({}),
+			interactive,
+		},
 	};
 }
 
@@ -165,5 +174,18 @@ describe("FindMcpTool", () => {
 		);
 		expect(fake.added).toEqual([]);
 		expect(res.forLLM).toContain("sub-agent cannot prompt");
+	});
+
+	it("never prompts or adds in a non-interactive run", async () => {
+		const fake = new FakeMcp([
+			server("postgres", "Postgres", "Query a Postgres database"),
+		]);
+		const tool = new FindMcpTool(() => fake);
+		const res = await tool.execute(
+			{ task: "query a postgres database" },
+			ctx("Add", 0, false),
+		);
+		expect(fake.added).toEqual([]);
+		expect(res.forLLM).toContain("non-interactive");
 	});
 });

--- a/tests/FindSkillTool.test.ts
+++ b/tests/FindSkillTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { EventBus } from "../src/core/bus/EventBus.ts";
+import { parseRuleSet } from "../src/core/permissions/PermissionRules.ts";
 import type { Skill } from "../src/core/skills/Skill.ts";
 import type { SkillsShListItem } from "../src/core/skills/skillsSh.ts";
 import type { ToolContext } from "../src/core/tools/ToolContext.ts";
@@ -65,14 +66,22 @@ class FakeSkills implements SkillActivator {
 	}
 }
 
-function ctx(answer = "Download", depth = 0): ToolContext {
+function ctx(answer = "Download", depth = 0, interactive = true): ToolContext {
 	return {
 		sessionId: "t",
 		cwd: "/tmp",
 		bus: new EventBus(),
 		signal: new AbortController().signal,
-		askUser: async () => answer,
+		askUser: async () => {
+			if (!interactive) throw new Error("unexpected prompt");
+			return answer;
+		},
 		agentDepth: depth,
+		permissions: {
+			mode: "auto",
+			rules: parseRuleSet({}),
+			interactive,
+		},
 	};
 }
 
@@ -187,5 +196,19 @@ describe("FindSkillTool", () => {
 		);
 		expect(fake.installed).toEqual([]);
 		expect(res.forLLM).toContain("sub-agent cannot prompt");
+	});
+
+	it("never prompts or downloads in a non-interactive run", async () => {
+		const fake = new FakeSkills(
+			[skill("commit", "git commit message")],
+			[remote("acme/pdf-tools", "pdf-tools", "2K")],
+		);
+		const tool = new FindSkillTool(fake);
+		const res = await tool.execute(
+			{ task: "pdf-tools please" },
+			ctx("Download", 0, false),
+		);
+		expect(fake.installed).toEqual([]);
+		expect(res.forLLM).toContain("non-interactive");
 	});
 });

--- a/tests/MCP.test.ts
+++ b/tests/MCP.test.ts
@@ -1083,6 +1083,39 @@ describe("McpToolAdapter", () => {
 		expect(destructive.isDestructive({})).toBe(true);
 	});
 
+	it("allows non-destructive MCP tools in auto mode", () => {
+		const tool = new McpToolAdapter(fakeDefinition({}));
+
+		expect(
+			tool.checkPermissions(
+				{},
+				{ mode: "auto", cwd: "/tmp", interactive: true },
+			),
+		).toEqual({
+			behavior: "allow",
+			reason: "non-destructive MCP tool (auto mode)",
+		});
+		expect(
+			tool.checkPermissions(
+				{},
+				{ mode: "acceptEdits", cwd: "/tmp", interactive: true },
+			),
+		).toBeUndefined();
+	});
+
+	it("keeps explicitly destructive MCP tools gated in auto mode", () => {
+		const tool = new McpToolAdapter(
+			fakeDefinition({ annotations: { destructiveHint: true } }),
+		);
+
+		expect(
+			tool.checkPermissions(
+				{},
+				{ mode: "auto", cwd: "/tmp", interactive: true },
+			),
+		).toBeUndefined();
+	});
+
 	it("ignores readOnlyHint until the user's config trusts the server", () => {
 		const claimed = { annotations: { readOnlyHint: true } };
 		const untrusted = new McpToolAdapter(

--- a/tests/MCP.test.ts
+++ b/tests/MCP.test.ts
@@ -1079,41 +1079,46 @@ describe("McpToolAdapter", () => {
 
 		expect(unannotated.isReadOnly({})).toBe(false);
 		expect(unannotated.isConcurrencySafe({})).toBe(false);
+		expect(unannotated.isDestructive({})).toBe(true);
 		expect(destructive.isReadOnly({})).toBe(false);
 		expect(destructive.isDestructive({})).toBe(true);
 	});
 
-	it("allows non-destructive MCP tools in auto mode", () => {
-		const tool = new McpToolAdapter(fakeDefinition({}));
+	it("does not auto-allow MCP tools from untrusted annotations", () => {
+		const tools = [
+			new McpToolAdapter(fakeDefinition({})),
+			new McpToolAdapter(
+				fakeDefinition({
+					annotations: { destructiveHint: false },
+					trustAnnotations: false,
+				}),
+			),
+		];
 
-		expect(
-			tool.checkPermissions(
-				{},
-				{ mode: "auto", cwd: "/tmp", interactive: true },
-			),
-		).toEqual({
-			behavior: "allow",
-			reason: "non-destructive MCP tool (auto mode)",
-		});
-		expect(
-			tool.checkPermissions(
-				{},
-				{ mode: "acceptEdits", cwd: "/tmp", interactive: true },
-			),
-		).toBeUndefined();
+		for (const tool of tools) {
+			expect(
+				tool.checkPermissions(
+					{},
+					{ mode: "auto", cwd: "/tmp", interactive: true },
+				),
+			).toBeUndefined();
+			expect(tool.isDestructive({})).toBe(true);
+		}
 	});
 
-	it("keeps explicitly destructive MCP tools gated in auto mode", () => {
-		const tool = new McpToolAdapter(
-			fakeDefinition({ annotations: { destructiveHint: true } }),
+	it("applies MCP annotation defaults only after trust", () => {
+		const additive = new McpToolAdapter(
+			fakeDefinition({
+				annotations: { destructiveHint: false },
+				trustAnnotations: true,
+			}),
+		);
+		const omitted = new McpToolAdapter(
+			fakeDefinition({ trustAnnotations: true }),
 		);
 
-		expect(
-			tool.checkPermissions(
-				{},
-				{ mode: "auto", cwd: "/tmp", interactive: true },
-			),
-		).toBeUndefined();
+		expect(additive.isDestructive({})).toBe(false);
+		expect(omitted.isDestructive({})).toBe(true);
 	});
 
 	it("ignores readOnlyHint until the user's config trusts the server", () => {

--- a/tests/PermissionEngine.test.ts
+++ b/tests/PermissionEngine.test.ts
@@ -13,6 +13,7 @@ import { ok, type ToolResult } from "../src/core/tools/ToolResult.ts";
 import { ApplyPatchTool } from "../src/tools/ApplyPatchTool.tsx";
 import { EditTool } from "../src/tools/EditTool.tsx";
 import { ExecuteTool } from "../src/tools/ExecuteTool.tsx";
+import { McpToolAdapter } from "../src/tools/MCPToolAdapter.tsx";
 import { WriteTool } from "../src/tools/WriteTool.tsx";
 
 const schema = z.object({ command: z.string().optional() });
@@ -330,5 +331,28 @@ describe("decidePermission in auto mode", () => {
 			"/tmp",
 		);
 		expect(decision.behavior).toBe("ask");
+	});
+
+	it("deny and ask rules override MCP auto mode", () => {
+		const mcp = new McpToolAdapter({
+			registeredName: "mcp__docs__search",
+			serverName: "docs",
+			toolName: "search",
+			description: "Search docs",
+			inputSchema: { type: "object" },
+			trustAnnotations: false,
+			timeoutMs: 1_000,
+			call: async () => ({ content: [] }),
+		});
+
+		for (const behavior of ["deny", "ask"] as const) {
+			const context = pctx({
+				mode: "auto",
+				rules: parseRuleSet({ [behavior]: [mcp.agentName] }),
+			});
+			expect(decidePermission(mcp, {}, context, "/tmp").behavior).toBe(
+				behavior,
+			);
+		}
 	});
 });

--- a/tests/PermissionEngine.test.ts
+++ b/tests/PermissionEngine.test.ts
@@ -355,4 +355,40 @@ describe("decidePermission in auto mode", () => {
 			);
 		}
 	});
+
+	it("prompts for unannotated MCP tools in auto mode", () => {
+		const mcp = new McpToolAdapter({
+			registeredName: "mcp__mailer__send_email",
+			serverName: "mailer",
+			toolName: "send_email",
+			description: "Send email",
+			inputSchema: { type: "object" },
+			trustAnnotations: false,
+			timeoutMs: 1_000,
+			call: async () => ({ content: [] }),
+		});
+
+		expect(
+			decidePermission(mcp, {}, pctx({ mode: "auto" }), "/tmp").behavior,
+		).toBe("ask");
+	});
+
+	it("allows trusted read-only MCP tools in auto mode", () => {
+		const mcp = new McpToolAdapter({
+			registeredName: "mcp__docs__search",
+			serverName: "docs",
+			toolName: "search",
+			description: "Search docs",
+			inputSchema: { type: "object" },
+			annotations: { readOnlyHint: true },
+			trustAnnotations: true,
+			timeoutMs: 1_000,
+			call: async () => ({ content: [] }),
+		});
+
+		expect(decidePermission(mcp, {}, pctx({ mode: "auto" }), "/tmp")).toEqual({
+			behavior: "allow",
+			reason: "read-only tool",
+		});
+	});
 });

--- a/tests/PermissionFlags.test.ts
+++ b/tests/PermissionFlags.test.ts
@@ -18,7 +18,7 @@ describe("--permission-mode flag", () => {
 });
 
 describe("buildPermissionContext", () => {
-	it("flag beats settings mode; default is manual", async () => {
+	it("flag beats settings mode; default is auto", async () => {
 		const cwd = await mkdtemp(join(tmpdir(), "perm-wire-"));
 		await mkdir(join(cwd, ".git"), { recursive: true });
 		await mkdir(join(cwd, ".backboard"), { recursive: true });
@@ -34,7 +34,7 @@ describe("buildPermissionContext", () => {
 		);
 		const fresh = await mkdtemp(join(tmpdir(), "perm-wire2-"));
 		await mkdir(join(fresh, ".git"), { recursive: true });
-		expect(buildPermissionContext(fresh, undefined, true).mode).toBe("manual");
+		expect(buildPermissionContext(fresh, undefined, true).mode).toBe("auto");
 	});
 
 	it("loads rules from settings and carries interactivity", async () => {

--- a/tests/PermissionFlags.test.ts
+++ b/tests/PermissionFlags.test.ts
@@ -49,4 +49,10 @@ describe("buildPermissionContext", () => {
 		expect(context.rules.allow).toHaveLength(1);
 		expect(context.interactive).toBe(false);
 	});
+
+	it("fails closed for an invalid explicit flag", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "perm-wire4-"));
+		await mkdir(join(cwd, ".git"), { recursive: true });
+		expect(buildPermissionContext(cwd, "manul", true).mode).toBe("manual");
+	});
 });

--- a/tests/PermissionGate.test.ts
+++ b/tests/PermissionGate.test.ts
@@ -12,6 +12,7 @@ import type { ToolContext } from "../src/core/tools/ToolContext.ts";
 import { ToolRegistry } from "../src/core/tools/ToolRegistry.ts";
 import { ok, type ToolResult } from "../src/core/tools/ToolResult.ts";
 import { ToolScheduler } from "../src/core/tools/ToolScheduler.ts";
+import { McpToolAdapter } from "../src/tools/MCPToolAdapter.tsx";
 
 const schema = z.object({ value: z.string().optional() });
 type Input = z.infer<typeof schema>;
@@ -52,7 +53,7 @@ function scheduler(tool: Tool): ToolScheduler {
 	return new ToolScheduler(registry, new EventBus());
 }
 
-async function runOne(tool: GatedTool, ctx: ToolContext) {
+async function runOne(tool: Tool, ctx: ToolContext) {
 	const sched = scheduler(tool);
 	return await sched.run(
 		[{ id: "call_1", name: tool.agentName, input: {} }],
@@ -101,5 +102,59 @@ describe("permission gate in the runner", () => {
 		ctx.permissions = undefined;
 		await runOne(tool, ctx);
 		expect(tool.ran).toBe(true);
+	});
+
+	it("does not execute unannotated MCP tools headlessly in auto mode", async () => {
+		let called = false;
+		const tool = new McpToolAdapter({
+			registeredName: "mcp__mailer__send_email",
+			serverName: "mailer",
+			toolName: "send_email",
+			description: "Send email",
+			inputSchema: { type: "object" },
+			trustAnnotations: false,
+			timeoutMs: 1_000,
+			call: async () => {
+				called = true;
+				return { content: [] };
+			},
+		});
+		const ctx = makeContext(
+			{ mode: "auto", rules: parseRuleSet({}), interactive: false },
+			ALLOW_ONCE,
+		);
+
+		const outputs = await runOne(tool, ctx);
+
+		expect(called).toBe(false);
+		expect(outputs[0]?.output).toContain("unavailable");
+		expect(outputs[0]?.metadata?.error).toBe(true);
+	});
+
+	it("executes trusted read-only MCP tools headlessly in auto mode", async () => {
+		let called = false;
+		const tool = new McpToolAdapter({
+			registeredName: "mcp__docs__search",
+			serverName: "docs",
+			toolName: "search",
+			description: "Search docs",
+			inputSchema: { type: "object" },
+			annotations: { readOnlyHint: true },
+			trustAnnotations: true,
+			timeoutMs: 1_000,
+			call: async () => {
+				called = true;
+				return { content: [] };
+			},
+		});
+		const ctx = makeContext(
+			{ mode: "auto", rules: parseRuleSet({}), interactive: false },
+			DENY,
+		);
+
+		const outputs = await runOne(tool, ctx);
+
+		expect(called).toBe(true);
+		expect(outputs[0]?.metadata?.error).toBe(false);
 	});
 });

--- a/tests/PermissionMode.test.ts
+++ b/tests/PermissionMode.test.ts
@@ -17,11 +17,11 @@ describe("PermissionMode", () => {
 		]);
 	});
 
-	it("parses valid modes and defaults to manual", () => {
+	it("parses valid modes and defaults to auto", () => {
 		expect(parsePermissionMode("bypass")).toBe("bypass");
 		expect(parsePermissionMode("acceptEdits")).toBe("acceptEdits");
-		expect(parsePermissionMode("nonsense")).toBe("manual");
-		expect(parsePermissionMode(undefined)).toBe("manual");
+		expect(parsePermissionMode("nonsense")).toBe("auto");
+		expect(parsePermissionMode(undefined)).toBe("auto");
 	});
 
 	it("recognizes known modes (for flag validation)", () => {

--- a/tests/PermissionMode.test.ts
+++ b/tests/PermissionMode.test.ts
@@ -20,7 +20,7 @@ describe("PermissionMode", () => {
 	it("parses valid modes and defaults to auto", () => {
 		expect(parsePermissionMode("bypass")).toBe("bypass");
 		expect(parsePermissionMode("acceptEdits")).toBe("acceptEdits");
-		expect(parsePermissionMode("nonsense")).toBe("auto");
+		expect(parsePermissionMode("nonsense")).toBe("manual");
 		expect(parsePermissionMode(undefined)).toBe("auto");
 	});
 
@@ -30,12 +30,12 @@ describe("PermissionMode", () => {
 		expect(isKnownPermissionMode(undefined)).toBe(false);
 	});
 
-	it("cycles manual → acceptEdits → auto → manual, excluding bypass", () => {
-		expect(nextPermissionMode("manual")).toBe("acceptEdits");
-		expect(nextPermissionMode("acceptEdits")).toBe("auto");
-		expect(nextPermissionMode("auto")).toBe("manual");
+	it("cycles auto → acceptEdits → manual → auto, excluding bypass", () => {
+		expect(nextPermissionMode("auto")).toBe("acceptEdits");
+		expect(nextPermissionMode("acceptEdits")).toBe("manual");
+		expect(nextPermissionMode("manual")).toBe("auto");
 		// bypass is flag-only; cycling out of it exits to the top.
-		expect(nextPermissionMode("bypass")).toBe("manual");
+		expect(nextPermissionMode("bypass")).toBe("auto");
 	});
 
 	it("labels modes for the status bar", () => {

--- a/tests/PermissionModeState.test.ts
+++ b/tests/PermissionModeState.test.ts
@@ -3,8 +3,8 @@ import { initialState } from "../src/state/AppState.ts";
 import { reduce } from "../src/state/Store.ts";
 
 describe("permission mode in app state", () => {
-	it("defaults to manual", () => {
-		expect(initialState("model-x").permissionMode).toBe("manual");
+	it("defaults to auto", () => {
+		expect(initialState("model-x").permissionMode).toBe("auto");
 	});
 
 	it("accepts an initial mode", () => {

--- a/tests/PermissionSettings.test.ts
+++ b/tests/PermissionSettings.test.ts
@@ -55,6 +55,18 @@ describe("permission settings", () => {
 		});
 	});
 
+	it("fails closed and warns for an invalid mode", async () => {
+		const cwd = await tempProject();
+		await mkdir(join(cwd, ".backboard"), { recursive: true });
+		await writeFile(
+			join(cwd, ".backboard", "settings.json"),
+			JSON.stringify({ permissions: { mode: "manul" } }),
+		);
+		const settings = loadPermissionSettings(cwd);
+		expect(settings.mode).toBe("manual");
+		expect(settings.warnings?.join("\n")).toContain("using manual mode");
+	});
+
 	it("appendAllowRule creates the file and preserves other keys", async () => {
 		const cwd = await tempProject();
 		await mkdir(join(cwd, ".backboard"), { recursive: true });

--- a/tests/PermissionToolClassification.test.ts
+++ b/tests/PermissionToolClassification.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../src/core/permissions/settings.ts";
 import { AskUserTool } from "../src/tools/AskUserTool.tsx";
 import { FetchUrlTool } from "../src/tools/FetchUrlTool.tsx";
+import { FindMcpTool } from "../src/tools/FindMcpTool.tsx";
+import { FindSkillTool } from "../src/tools/FindSkillTool.tsx";
 import { TodoWriteTool } from "../src/tools/TodoWriteTool.tsx";
 import { WebSearchTool } from "../src/tools/WebSearchTool.tsx";
 
@@ -49,6 +51,38 @@ describe("internal tools never gate on permission", () => {
 	it("AskUserTool.checkPermissions allows", () => {
 		const decision = new AskUserTool().checkPermissions();
 		expect(decision?.behavior).toBe("allow");
+	});
+});
+
+describe("discovery tools in auto mode", () => {
+	const auto = { mode: "auto" as const, cwd: "/project", interactive: true };
+	const manual = {
+		mode: "manual" as const,
+		cwd: "/project",
+		interactive: true,
+	};
+
+	it("allows MCP discovery before its own confirmation gate", () => {
+		const tool = new FindMcpTool(() => undefined);
+		expect(tool.checkPermissions({ task: "docs" }, auto)?.behavior).toBe(
+			"allow",
+		);
+		expect(tool.checkPermissions({ task: "docs" }, manual)).toBeUndefined();
+	});
+
+	it("allows skill discovery before its own confirmation gate", () => {
+		const tool = new FindSkillTool({
+			listLocalSkills: async () => [],
+			activateSkill: () => ({ selectedName: "", loadedNames: [] }),
+			listRemoteSkills: async () => [],
+			installRemoteSkill: async () => {
+				throw new Error("not used");
+			},
+		});
+		expect(tool.checkPermissions({ task: "docs" }, auto)?.behavior).toBe(
+			"allow",
+		);
+		expect(tool.checkPermissions({ task: "docs" }, manual)).toBeUndefined();
 	});
 });
 

--- a/tests/PermissionToolClassification.test.ts
+++ b/tests/PermissionToolClassification.test.ts
@@ -61,6 +61,11 @@ describe("discovery tools in auto mode", () => {
 		cwd: "/project",
 		interactive: true,
 	};
+	const headlessAuto = {
+		mode: "auto" as const,
+		cwd: "/project",
+		interactive: false,
+	};
 
 	it("allows MCP discovery before its own confirmation gate", () => {
 		const tool = new FindMcpTool(() => undefined);
@@ -68,9 +73,12 @@ describe("discovery tools in auto mode", () => {
 			"allow",
 		);
 		expect(tool.checkPermissions({ task: "docs" }, manual)).toBeUndefined();
+		expect(
+			tool.checkPermissions({ task: "docs" }, headlessAuto),
+		).toBeUndefined();
 	});
 
-	it("allows skill discovery before its own confirmation gate", () => {
+	it("keeps skill discovery gated because local activation has no confirmation", () => {
 		const tool = new FindSkillTool({
 			listLocalSkills: async () => [],
 			activateSkill: () => ({ selectedName: "", loadedNames: [] }),
@@ -79,10 +87,11 @@ describe("discovery tools in auto mode", () => {
 				throw new Error("not used");
 			},
 		});
-		expect(tool.checkPermissions({ task: "docs" }, auto)?.behavior).toBe(
-			"allow",
-		);
+		expect(tool.checkPermissions({ task: "docs" }, auto)).toBeUndefined();
 		expect(tool.checkPermissions({ task: "docs" }, manual)).toBeUndefined();
+		expect(
+			tool.checkPermissions({ task: "docs" }, headlessAuto),
+		).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Summary
- make Auto the default permission mode for new sessions
- keep unannotated and untrusted MCP tools behind the permission gate
- allow only explicitly trusted read-only MCP tools to use the read-only shortcut
- keep local skill discovery gated, while allowing interactive MCP discovery before its own confirmation step
- fail closed to Manual for malformed CLI or project permission modes and surface a project-settings warning
- cycle Shift+Tab from Auto to Accept Edits to Manual
- prevent discovery confirmation prompts in non-interactive execution paths
- update CLI help, README security guidance, and end-to-end regression coverage

## Validation
- `bun run validate`
- 1,577 tests passed, 3 skipped

Stacked on #18.