### PR TITLE
Bump shell-quote to 1.10.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -576,7 +576,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 


### PR DESCRIPTION
Closes #21.

Updates the locked `shell-quote` version from 1.8.4 to 1.10.0 to resolve CVE-2026-13311 (quadratic-time `parse()`).

`shell-quote` is not a direct dependency. It is pulled in by `react-devtools-core` (`^1.6.1`) and `@daytona/sdk` (`^1.8.2`), and both ranges already allow the fixed version, so this is a lockfile-only change with no edit to `package.json`.

Verified with `bun install --frozen-lockfile`, `bun run validate`, and `bun audit`, which no longer lists `shell-quote`.
